### PR TITLE
Fixed the issue of `markParam!` not giving correct indices sometimes.

### DIFF
--- a/docs/src/basis.md
+++ b/docs/src/basis.md
@@ -207,14 +207,14 @@ julia> bs7 = genBasisFunc.([[0.0, 0.1, 0.0], [1.4, 0.3, 0.0]], Ref(gf4));
 julia> markParams!(bs7)
 10-element Vector{ParamBox{Float64, V, FLevel{0}} where V}:
  ParamBox{Float64, :X, FLevel{0}}(0.0)[∂][X₁]
- ParamBox{Float64, :X, FLevel{0}}(1.4)[∂][X₂]
  ParamBox{Float64, :Y, FLevel{0}}(0.1)[∂][Y₁]
- ParamBox{Float64, :Y, FLevel{0}}(0.3)[∂][Y₂]
  ParamBox{Float64, :Z, FLevel{0}}(0.0)[∂][Z₁]
- ParamBox{Float64, :Z, FLevel{0}}(0.0)[∂][Z₂]
- ParamBox{Float64, :α, FLevel{0}}(2.5)[∂][α₁]
  ParamBox{Float64, :α, FLevel{0}}(2.5)[∂][α₁]
  ParamBox{Float64, :d, FLevel{0}}(0.5)[∂][d₁]
+ ParamBox{Float64, :X, FLevel{0}}(1.4)[∂][X₂]
+ ParamBox{Float64, :Y, FLevel{0}}(0.3)[∂][Y₂]
+ ParamBox{Float64, :Z, FLevel{0}}(0.0)[∂][Z₂]
+ ParamBox{Float64, :α, FLevel{0}}(2.5)[∂][α₁]
  ParamBox{Float64, :d, FLevel{0}}(0.5)[∂][d₁]
 ```
 

--- a/src/Basis.jl
+++ b/src/Basis.jl
@@ -1872,33 +1872,57 @@ markParams!(b::Union{AbstractVector{T}, T, Tuple{Vararg{T}}},
             filterMapping::Bool=false) where {T<:ParameterizedContainer} = 
 markParams!(getParams(b), filterMapping)
 
-function markParams!(parArray::AbstractVector{<:ParamBox}, filterMapping::Bool=false)
-    pars = eltype(parArray)[]
-    syms = getUnique!(outSymOfCore.(parArray))
-    arr = parArray |> copy
-    for sym in syms
-        typ = ParamBox{<:Any, sym}
-        subArr = typ[]
-        ids = Int[]
-        for (i, val) in enumerate(arr)
-            if val isa typ
-                push!(subArr, val)
-                push!(ids, i)
-            end
-        end
-        deleteat!(arr, ids)
-        append!(pars, markParamsCore!(subArr))
+# function markParams!(parArray::AbstractVector{<:ParamBox}, filterMapping::Bool=false)
+#     pars = eltype(parArray)[]
+#     syms = getUnique!(outSymOfCore.(parArray))
+#     arr = parArray |> copy
+#     for sym in syms
+#         typ = ParamBox{<:Any, sym}
+#         subArr = typ[]
+#         ids = Int[]
+#         for (i, val) in enumerate(arr)
+#             if val isa typ
+#                 push!(subArr, val)
+#                 push!(ids, i)
+#             end
+#         end
+#         deleteat!(arr, ids)
+#         append!(pars, markParamsCore!(subArr))
+#     end
+#     filterMapping ? unique(x->(objectid(x.data), x.index[]), pars) : pars
+# end
+
+# function markParamsCore!(parArray::AbstractVector{<:ParamBox{<:Any, V}}) where {V}
+#     res, _ = markUnique(parArray, compareFunction=compareParamBox)
+#     for (idx, i) in zip(parArray, res)
+#         idx.index[] = i
+#     end
+#     parArray
+# end
+
+function markParams!(pars::AbstractVector{<:ParamBox}, filterMapping::Bool=false)
+    uniqueParams = eltype(pars)[]
+    parsSorted = eltype(pars)[]
+    ids1, items = markUnique(outSymOfCore.(pars))
+    # inVarDict = Dict{Sym, Vector{Pair{UInt, Int}}}()
+    for i= 1:length(items)
+        parsSameV = view(pars, findall(isequal(i), ids1))
+        append!(uniqueParams, markParamsCore1!(parsSameV))
+        append!(parsSorted, parsSameV)
     end
-    filterMapping ? unique(x->(objectid(x.data), x.index[]), pars) : pars
+    filterMapping ? unique(x->(objectid(x.data), x.index[]), parsSorted) : parsSorted
 end
 
-function markParamsCore!(parArray::AbstractVector{<:ParamBox{<:Any, V}}) where {V}
-    res, _ = markUnique(parArray, compareFunction=compareParamBox)
-    for (idx, i) in zip(parArray, res)
+function markParamsCore1!(pars::AbstractVector{<:ParamBox})
+    ids, uniqueParams = markUnique(pars, compareFunction=compareParamBox)
+    for (idx, i) in zip(pars, ids)
         idx.index[] = i
     end
-    parArray
+    uniqueParams
 end
+
+markParams!(parTuple::Tuple{Vararg{ParamBox}}, filterMapping::Bool=false) = 
+markParams!(collect(parTuple), filterMapping)
 
 
 """

--- a/src/Overload.jl
+++ b/src/Overload.jl
@@ -53,6 +53,8 @@ function typeStrOf(bT::Type{<:FloatingGTBasisFuncs{<:Any, <:Any, <:Any, <:Any, P
     replace(bTstrO, pbsTstrO=>pbsTstrN, count=1)
 end
 
+typeStrOf(::Type{T}) where {T<:FloatingGTBasisFuncs} = string(T)
+
 typeStrOf(::T) where {T<:FloatingGTBasisFuncs} = typeStrOf(T)
 
 function typeStrOf(gbT::Type{<:GridBox{<:Any, <:Any, <:Any, SPT}}) where {SPT}

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -400,7 +400,7 @@ Change the mapping function of `pb`. The name of the output variable of the retu
 function changeMapping(pb::ParamBox{T, V, FL}, mapFunction::F, outputName::Symbol=V; 
                        canDiff::Bool=true) where {T, V, FL, F<:Function}
     dn = pb.dataName
-    if (FL==FI && FLevel(F)!=FI) 
+    if (FL==FI && FLevel(F)!=FI)
         dnStr = string(dn)
         dn = Symbol(dnStr * "_" * dnStr)
     end

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -1,6 +1,6 @@
 export ParamBox, inValOf, inSymOf, inSymOfCore, inSymValOf, outValOf, outSymOf, 
        outSymOfCore, outSymValOf, dataOf, mapOf, getVar, getVarDict, outValCopy, inVarCopy, 
-       enableDiff!, disableDiff!, isDiffParam, toggleDiff!, changeMapping
+       enableDiff!, disableDiff!, isDiffParam, toggleDiff!, isDepParam, changeMapping
 
 export FLevel
 
@@ -385,6 +385,17 @@ isDiffParam(pb::ParamBox) = pb.canDiff[]
 Toggle the differentiability of the input `pb` and then return it.
 """
 toggleDiff!(pb::ParamBox) = begin pb.canDiff[] = !isDiffParam(pb) end
+
+
+"""
+
+    isDepParam(pb::ParamBox) -> Bool
+
+Return the Boolean value of if `pb` is considered a dependent parameter that is a 
+differentiable function with respect to the input variable it stores.
+"""
+isDepParam(pb::ParamBox{<:Any, <:Any, FI}) = false
+isDepParam(pb::ParamBox{<:Any, <:Any, FL}) where {FL} = isDiffParam(pb)
 
 
 """

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -862,5 +862,23 @@ end
 isNaN(::Any) = false
 isNaN(n::Number) = isnan(n)
 
+
 getBool(bl::Bool) = itself(bl)
 getBool(::Val{BL}) where {BL} = BL::Bool
+
+
+function skipIndices(arr::AbstractArray{Int}, ints::AbstractVector{Int})
+    @assert min(arr...) > 0
+    if isempty(ints)
+        arr
+    else
+        @assert min(ints...) > 0
+        maxIdx = max(arr...)
+        maxIdxN = maxIdx + length(ints)
+        ints = filter!(x->x<=maxIdxN, sort(ints))
+        idsN = deleteat!(collect(1:maxIdxN), ints)
+        map(arr) do x
+            idsN[x]
+        end
+    end
+end

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -511,7 +511,7 @@ end
 """
 function markUnique(arr::AbstractArray{T}, args...; 
                     compareFunction::F=hasEqual, kws...) where {T<:Any, F<:Function}
-    @assert length(arr) >= 1 "The length of input array should be not less than 1."
+    isempty(arr) && (return arr)
     f = (b...)->compareFunction((b..., args...)...; kws...)
     res = Int[1]
     cmprList = T[arr[1]]
@@ -561,7 +561,7 @@ julia> arr
 """
 function getUnique!(arr::AbstractVector{T}, args...; 
                     compareFunction::F = hasEqual, kws...) where {T<:Any, F<:Function}
-    @assert length(arr) > 0 "The length of input array should be larger than 0."
+    isempty(arr) && (return arr)
     f = (b...)->compareFunction((b..., args...)...; kws...)
     cmprList = T[arr[1]]
     delList = Bool[false]

--- a/test/unit-tests/Basis-test.jl
+++ b/test/unit-tests/Basis-test.jl
@@ -769,24 +769,19 @@ bf_gv5 = genBasisFunc(cen_gv3, gf_gv1)
 bf_gv6 = genBasisFunc(cen_gv3, [gf_gv12, gf_gv23, gf_gv31])
 bfm_gv = BasisFuncMix([bf_gv2, bf_gv4, bf_gv6])
 
-@test markParams!(bf_gv4) == [cen_gv1..., e_gv3, c_gv3]
+@test markParams!(bf_gv4) == [cen_gv1..., e_gv3, c_gv3] == markParams!(bf_gv4.param)
 
 pbs_gv1 = markParams!([bf_gv1, bf_gv2])
-pbs_gv1_0 = [cen_gv1[1], cen_gv2[1], 
-             cen_gv1[2], cen_gv2[2], 
-             cen_gv1[3], cen_gv2[3], 
-                  e_gv1,      e_gv2, 
-                  c_gv1,      c_gv2]
+pbs_gv1_0 = [cen_gv1[1], cen_gv1[2], cen_gv1[3], e_gv1, c_gv1, 
+             cen_gv2[1], cen_gv2[2], cen_gv2[3], e_gv2, c_gv2]
 @test pbs_gv1 == pbs_gv1_0
 @test hasIdentical(pbs_gv1, pbs_gv1_0)
 
 pbs_gv2 = markParams!([bf_gv2, bf_gv1, bf_gv3])
 
-pbs_gv2_0 = [cen_gv2[1], cen_gv1[1], cen_gv2[1], 
-             cen_gv2[2], cen_gv1[2], cen_gv2[2], 
-             cen_gv2[3], cen_gv1[3], cen_gv2[3], 
-             e_gv2, e_gv1, e_gv1, e_gv2,
-             c_gv2, c_gv1, c_gv1, c_gv2]
+pbs_gv2_0 = [cen_gv2[1], cen_gv2[2], cen_gv2[3], e_gv2, c_gv2, 
+             cen_gv1[1], cen_gv1[2], cen_gv1[3], e_gv1, c_gv1, 
+             cen_gv2[1], cen_gv2[2], cen_gv2[3], e_gv1, c_gv1, e_gv2, c_gv2]
 @test pbs_gv2 == pbs_gv2_0
 @test hasIdentical(pbs_gv2, pbs_gv2_0)
 
@@ -807,6 +802,18 @@ pbs_gv3_2 = sort(pbs_gv3, by=x->(typeof(x).parameters[2], x.index[]))
 @test pbs_gv3_2 == pbs_gv0_2
 @test hasEqual(pbs_gv3_2, pbs_gv0_2)
 @test hasIdentical(pbs_gv3_2, pbs_gv0_2)
+
+pb_gv1 = ParamBox(1.0, :X, x->x+1, :I)
+pb_gv2 = ParamBox(1.0, :Y, x->x+2, :I)
+pb_gv3 = ParamBox(1.0, :Z, x->x+3, :I)
+sp_gv1 = genSpatialPoint((pb_gv1, pb_gv2, pb_gv3))
+gf_gv4 = GaussFunc(genExponent(pb_gv1), genContraction(pb_gv3))
+gf_gv5 = GaussFunc(genExponent(pb_gv2), genContraction(0.5))
+bf_gv7 = genBasisFunc(sp_gv1, (gf_gv4, gf_gv5))
+pars_gv = markParams!(bf_gv7, true)
+@test pars_gv == [pb_gv1, pb_gv2, pb_gv3, gf_gv5.con]
+@test getVar.(pars_gv) == [:X₁, :Y₂, :Z₃, :d₁]
+@test getVar.(pars_gv, true) == [:I₁, :I₂, :I₃, :d₁]
 
 
 # function hasNormFactor getNormFactor

--- a/test/unit-tests/Differentiation-test.jl
+++ b/test/unit-tests/Differentiation-test.jl
@@ -86,7 +86,7 @@ nucCoords = [[-0.7,0.0,0.0], [0.7,0.0,0.0]]
 grid = GridBox(1, 3.0)
 gf1 = GaussFunc(0.7, 1.0)
 bs1 = genBasisFunc.(grid.point, Ref([gf1]))
-pars1 = markParams!(bs1)[[1, 9, 25, 33]]
+pars1 = markParams!(bs1)[[1, 2, 4, 5]]
 S1 = overlaps(bs1)
 HFres1 = runHF(bs1, nuc, nucCoords, DHFO, printInfo=false)
 grad1 = gradOfHFenergy(pars1, bs1, S1, HFres1.C, nuc, nucCoords)

--- a/test/unit-tests/Optimization-test.jl
+++ b/test/unit-tests/Optimization-test.jl
@@ -49,7 +49,7 @@ local Es2L, ps2L, grads2L
 end
 
 E_t2 = -1.16652582930629
-# L, α
+# L₁, α₁
 par_t2  = [2.846505123098946, 0.225501045327590]
 grad_t2 = [0.375222524865646, 0.683095213465142]
 @test Es2L[1] > Es2L[end]
@@ -64,7 +64,7 @@ grid2 = GridBox(1, 3.0)
 bs2_2 = genBasisFunc.(grid2.point, Ref([gf2_2]))
 gf3 = GaussFunc(0.5, 1.0)
 bs3 = bs2_2 .+ genBasisFunc(fill(0.0, 3), gf3)
-pars3 = markParams!(bs3, true)[[1,5:end...]]
+pars3 = markParams!(bs3, true)[1:5]
 local Es3L, ps3L, grads3L
 
 @suppress_out begin

--- a/test/unit-tests/Overload-test.jl
+++ b/test/unit-tests/Overload-test.jl
@@ -50,14 +50,16 @@ bfs3 = genBasisFunc([0.0, 0.0, 0.0], (2.0, 1.0), [(2,0,0), (1,1,0)])
 bfe = Quiqbox.EmptyBasisFunc{Float64, 3}()
 @test (@capture_out show(bfe)) == string(typeof(bfe))
 
-bfm1 = BasisFuncMix([bf1, bf2])
+box1 = GridBox(2, 1.5)
+@test (@capture_out show(box1)) == string(typeStrOf(box1))*getFieldNameStr(box1)
+
+bf3 = genBasisFunc(box1.point[1], (2.0, 1.0))
+
+bfm1 = BasisFuncMix([bf1, bf2, bf3])
 @test (@capture_out show(bfm1)) == string(typeStrOf(bfm1))*getFieldNameStr(bfm1)
 
 GTb1 = GTBasis([bf1, bfs2])
 @test (@capture_out show(GTb1)) == string(typeof(GTb1))*getFieldNameStr(GTb1)
-
-box1 = GridBox(2, 1.5)
-@test (@capture_out show(box1)) == string(typeStrOf(box1))*getFieldNameStr(box1)
 
 fVar1 = runHF(GTb1, ["H", "H"], [[0.0, 0.0, 0.0], [1.0, 2.0, 1.0]], HFconfig((C0=:Hcore,)), 
               printInfo=false)

--- a/test/unit-tests/Parameters-test.jl
+++ b/test/unit-tests/Parameters-test.jl
@@ -10,7 +10,9 @@ pb1 = ParamBox(1, :a)
 @test pb1[] == pb1() == 1 == outValOf(pb1)
 @test pb1.map == Quiqbox.itself == mapOf(pb1)
 @test pb1.canDiff[] == false == isDiffParam(pb1)
+@test !isDepParam(pb1)
 toggleDiff!(pb1)
+@test !isDepParam(pb1)
 @test pb1.canDiff[] == true
 disableDiff!(pb1)
 @test pb1.canDiff[] == false
@@ -26,6 +28,9 @@ pb3 = ParamBox(-1, :b, abs)
 @test inSymOfCore(pb3) == :x_b
 @test outSymOfCore(pb3) == :b
 @test mapOf(pb3) == abs
+@test isDepParam(pb3)
+toggleDiff!(pb3)
+@test !isDepParam(pb3)
 
 pb4 = ParamBox(1.2, :c, x->x^2, :x)
 @test inSymOfCore(pb4) == :x
@@ -101,7 +106,7 @@ markParams!(vcat(bfs_gv, bfm_gv), true)
 @test getVarDict(pb4) == Dict([:x=>1.2, :c=>1.44])
 pb1_2 = changeMapping(pb1, x->x+2)
 @test getVarDict(pb1_2) == Dict(:a_a=>1, :a=>3)
-@test getVarDict(pb3) == Dict(:x_b=>-1, :b=>1)
+@test getVarDict(pb3) == Dict(:b=>1)
 pb4_3 = changeMapping(pb4, x->x+2)
 @test getVarDict(pb4_3) == Dict(:c=>3.2, :x=>1.2)
 @test getVarDict(bf_gv6.param) == Dict( ( (  getVar.(bf_gv6.param) .=> 

--- a/test/unit-tests/Parameters-test.jl
+++ b/test/unit-tests/Parameters-test.jl
@@ -94,15 +94,16 @@ bfm_gv = Quiqbox.BasisFuncMix([bf_gv2, bf_gv4, bf_gv6])
 bfs_gv = sortBasisFuncs([bf_gv1, bf_gv2, bf_gv3, bf_gv4, bf_gv5, bf_gv6])
 markParams!(bfs_gv, true)
 markParams!(vcat(bfs_gv, bfm_gv), true)
-@test getVar.(bf_gv6.param) == (:X₁, :Y₂, :Z₂, :α₁, :d₃, :α₃, :d₂, :α₂, :d₁)
-@test getVar.(bf_gv6.param, true) == (:X₁, :Y₂, :Z₂, :α₁, :d₃, :α₃, :d₂, :x_α₂, :d₁)
-@test getVar.(bfm_gv.param) == (:X₁, :Y₁, :Z₁, :α₂, :d₂, :X₁, :Y₂, :Z₂, :α₁, :d₃, :α₃, :d₂, 
-                                :α₂, :d₁, :X₂, :Y₂, :Z₃, :α₃, :d₃)
-@test getVar.(bfm_gv.param, true) == (:X₁, :Y₁, :Z₁, :x_α₂, :d₂, :X₁, :Y₂, :Z₂, :α₁, :d₃, 
-                                      :α₃, :d₂, :x_α₂, :d₁, :X₂, :Y₂, :Z₃, :α₃, :d₃)
+sortTuple = t -> (collect(t) |> sort)
+@test sortTuple(getVar.(bf_gv6.param)) == [:X₁, :Y₂, :Z₂, :d₁, :d₂, :d₃, :α₁, :α₂, :α₃]
+@test sortTuple(getVar.(bf_gv6.param, true)) == [:X₁, :Y₂, :Z₂, 
+                                                 :d₁, :d₂, :d₃, :x_α₁, :α₂, :α₃]
+@test sortTuple(getVar.(bfm_gv.param)) == [:X₁, :X₁, :X₂, :Y₁, :Y₂, :Y₂, :Z₁, :Z₂, :Z₃, 
+                                           :d₁, :d₂, :d₂, :d₃, :d₃, :α₁, :α₁, :α₂, :α₃, :α₃]
+@test sortTuple(getVar.(bfm_gv.param, true)) == [:X₁, :X₁, :X₂, :Y₁, :Y₂, :Y₂, :Z₁, :Z₂, :Z₃, :d₁, :d₂, :d₂, :d₃, :d₃, :x_α₁, :x_α₁, :α₂, :α₃, :α₃]
 
 
-@test getVarDict(e_gv1) == Dict(:α₁=>2.0)
+@test getVarDict(e_gv1) == Dict(:α₂=>2.0)
 @test getVarDict(pb4) == Dict([:x=>1.2, :c=>1.44])
 pb1_2 = changeMapping(pb1, x->x+2)
 @test getVarDict(pb1_2) == Dict(:a_a=>1, :a=>3)

--- a/test/unit-tests/Tools-test.jl
+++ b/test/unit-tests/Tools-test.jl
@@ -5,7 +5,7 @@ using Quiqbox: getAtolVal, getAtolDigits, roundToMultiOfStep, nearestHalfOf, get
                markUnique, getUnique!, itself, themselves, replaceSymbol, renameFunc, 
                groupedSort, mapPermute, TypedFunction, Pf, Sf, getFunc, nameOf, tupleDiff, 
                genIndex, fillObj, arrayToTuple, genTupleCoords, callGenFunc, uniCallFunc, 
-               mergeMultiObjs, isNaN, getBool
+               mergeMultiObjs, isNaN, getBool, skipIndices
 using Suppressor: @capture_out
 
 @testset "Tools.jl" begin
@@ -260,5 +260,16 @@ mergeFunc1 = (x,y; atol) -> ifelse(isapprox(abs(x), abs(y); atol), [abs(x)], abs
 # function getBool
 @test getBool(true)
 @test getBool(Val(true))
+
+
+# function skipIndices
+idsR1 = [3, 6, 7, 11, 12, 15, 18]
+idsR2 = [3, 6, 11, 7, 15, 12, 18]
+idsT = [1, 2, 6, 5, 6, 7, 8, 4, 9, 10, 3]
+@test skipIndices(idsT, idsR1) == skipIndices(idsT, idsR2) == 
+      [1, 2, 9, 8, 9, 10, 13, 5, 14, 16, 4]
+@test skipIndices(idsT, Int[]) === idsT
+@test try skipIndices(idsT, [-1, 2]) catch; true end
+@test try skipIndices([-1, 2, 3], idsR1) catch; true end
 
 end


### PR DESCRIPTION
When multiple `ParamBox`s are marked as the dependent variables, even when the input variables (`.data`) have the same symbols, they should have different indices if `.data`s are not identical.