### PR TITLE
0.5-Improvement Dev

### DIFF
--- a/docs/src/basis.md
+++ b/docs/src/basis.md
@@ -8,8 +8,8 @@ The data structures defined by Quiqbox in each step, form levels of data complex
 | :---:  |   :---:   |      :---:      |     :---:    |
 | 4 | basis set | `Array`, `Tuple`, `GTBasis` | `Vector{<:BasisFunc{Float64, 3}}`, `GTBasis{Float64, 3, 2}`...|
 | 3 | basis function | `GTBasisFuncs` | `BasisFunc{Float64, 3, 0, 6}`, `Quiqbox.BasisFuncMix{Float64, 3, 2}`...|
-| 2 | Gaussian-type function | `AbstractGaussFunc` | `GaussFunc{Float64, FLevel{0}, FLevel{0}}`...|
-| 1 | tunable parameter | `ParamBox`, `SpatialPoint` | `ParamBox{Float64, :α, FLevel{0}}`, `SpatialPoint{Float64, 3, P3D{Float64, 0, 0, 0}}`... |
+| 2 | Gaussian-type function | `AbstractGaussFunc` | `GaussFunc{Float64, iT, iT}`...|
+| 1 | tunable parameter | `ParamBox`, `SpatialPoint` | `ParamBox{Float64, :α, iT}`, `SpatialPoint{Float64, 3, P3D{Float64, 0, 0, 0}}`... |
 
 Depending on how much control the user wants to have over each step, Quiqbox defines several [methods](https://docs.julialang.org/en/v1/manual/methods/) of related functions to provide the freedom of balancing between efficiency and customizability.
 
@@ -40,7 +40,7 @@ If you want to postpone the specification of the center, you can replace the fir
 julia> bsO = genBasisFunc(missing, "STO-3G", "O");
 
 julia> [assignCenInVal!(b, fill(1.0, 3)) for b in bsO]
-3-element Vector{SpatialPoint{Float64, 3, Tuple{ParamBox{Float64, :X, FLevel{0}}, ParamBox{Float64, :Y, FLevel{0}}, ParamBox{Float64, :Z, FLevel{0}}}}}:
+3-element Vector{SpatialPoint{Float64, 3, Tuple{ParamBox{Float64, :X, typeof(itself)}, ParamBox{Float64, :Y, typeof(itself)}, ParamBox{Float64, :Z, typeof(itself)}}}}:
  SpatialPoint{Float64, 3, P3D{Float64, 0, 0, 0}}(param)[1.0, 1.0, 1.0][∂][∂][∂]
  SpatialPoint{Float64, 3, P3D{Float64, 0, 0, 0}}(param)[1.0, 1.0, 1.0][∂][∂][∂]
  SpatialPoint{Float64, 3, P3D{Float64, 0, 0, 0}}(param)[1.0, 1.0, 1.0][∂][∂][∂]
@@ -49,11 +49,11 @@ julia> [assignCenInVal!(b, fill(1.0, 3)) for b in bsO]
 If you omit the atom in the arguments, `"H"` will be set in default. Notice that even though there's only one single basis function in H's STO-3G basis set, the returned value is still a `Vector`.
 ```jldoctest myLabel1
 julia> bsH_1 = genBasisFunc([-0.5, 0, 0], "STO-3G")
-1-element Vector{BasisFunc{Float64, 3, 0, 3, Tuple{ParamBox{Float64, :X, FLevel{0}}, ParamBox{Float64, :Y, FLevel{0}}, ParamBox{Float64, :Z, FLevel{0}}}}}:
+1-element Vector{BasisFunc{Float64, 3, 0, 3, Tuple{ParamBox{Float64, :X, typeof(itself)}, ParamBox{Float64, :Y, typeof(itself)}, ParamBox{Float64, :Z, typeof(itself)}}}}:
  BasisFunc{Float64, 3, 0, 3, P3D{Float64, 0, 0, 0}}(center, gauss, l, normalizeGTO, param)[X⁰Y⁰Z⁰][-0.5, 0.0, 0.0]
 
 julia> bsH_2 = genBasisFunc([ 0.5, 0, 0], "STO-3G")
-1-element Vector{BasisFunc{Float64, 3, 0, 3, Tuple{ParamBox{Float64, :X, FLevel{0}}, ParamBox{Float64, :Y, FLevel{0}}, ParamBox{Float64, :Z, FLevel{0}}}}}:
+1-element Vector{BasisFunc{Float64, 3, 0, 3, Tuple{ParamBox{Float64, :X, typeof(itself)}, ParamBox{Float64, :Y, typeof(itself)}, ParamBox{Float64, :Z, typeof(itself)}}}}:
  BasisFunc{Float64, 3, 0, 3, P3D{Float64, 0, 0, 0}}(center, gauss, l, normalizeGTO, param)[X⁰Y⁰Z⁰][0.5, 0.0, 0.0]
 ```
 
@@ -130,10 +130,10 @@ genBFuncsFromText(txt_Kr_631G, adjustContent=true);
 If you want to specify the parameters of each basis function when constructing a basis set, you can first construct the container for primitive GTO: `GaussFunc`, and then construct the basis function from them:
 ```jldoctest myLabel2; setup = :( push!(LOAD_PATH,"../../src/"); using Quiqbox )
 julia> gf1 = GaussFunc(2.0, 1.0)
-GaussFunc{Float64, FLevel{0}, FLevel{0}}(xpn()=2.0, con()=1.0, param)
+GaussFunc{Float64, iT, iT}(xpn()=2.0, con()=1.0, param)
 
 julia> gf2 = GaussFunc(2.5, 0.75)
-GaussFunc{Float64, FLevel{0}, FLevel{0}}(xpn()=2.5, con()=0.75, param)
+GaussFunc{Float64, iT, iT}(xpn()=2.5, con()=0.75, param)
 
 julia> bf1 = genBasisFunc([1.0, 0, 0], [gf1, gf2])
 BasisFunc{Float64, 3, 0, 2, P3D{Float64, 0, 0, 0}}(center, gauss, l, normalizeGTO, param)[X⁰Y⁰Z⁰][1.0, 0.0, 0.0]
@@ -167,15 +167,15 @@ true
 Sometimes you may want the parameters of basis functions (or `GaussFunc`) to be under some constraints (which can be crucial for the later basis set optimization), this is when you need a deeper level of control over the parameters, through its direct container: [`ParamBox`](@ref). In fact, in the above example, we have already had a glimpse of it through the printed info in the REPL:
 ```jldoctest myLabel2
 julia> gf1
-GaussFunc{Float64, FLevel{0}, FLevel{0}}(xpn()=2.0, con()=1.0, param)
+GaussFunc{Float64, iT, iT}(xpn()=2.0, con()=1.0, param)
 ```
 The two fields of a `GaussFunc`, `.xpn`, and `.con` are `ParamBox`, and their input value (i.e. the value of the input variable) can be accessed through syntax `[]`:
 ```jldoctest myLabel2
 julia> gf1.xpn
-ParamBox{Float64, :α, FLevel{0}}(2.0)[∂][α]
+ParamBox{Float64, :α, iT}(2.0)[∂][α]
 
 julia> gf1.con
-ParamBox{Float64, :d, FLevel{0}}(1.0)[∂][d]
+ParamBox{Float64, :d, iT}(1.0)[∂][d]
 
 julia> gf1.xpn[]
 2.0
@@ -205,17 +205,17 @@ julia> gf4 = GaussFunc(2.5, 0.5);
 julia> bs7 = genBasisFunc.([[0.0, 0.1, 0.0], [1.4, 0.3, 0.0]], Ref(gf4));
 
 julia> markParams!(bs7)
-10-element Vector{ParamBox{Float64, V, FLevel{0}} where V}:
- ParamBox{Float64, :X, FLevel{0}}(0.0)[∂][X₁]
- ParamBox{Float64, :Y, FLevel{0}}(0.1)[∂][Y₁]
- ParamBox{Float64, :Z, FLevel{0}}(0.0)[∂][Z₁]
- ParamBox{Float64, :α, FLevel{0}}(2.5)[∂][α₁]
- ParamBox{Float64, :d, FLevel{0}}(0.5)[∂][d₁]
- ParamBox{Float64, :X, FLevel{0}}(1.4)[∂][X₂]
- ParamBox{Float64, :Y, FLevel{0}}(0.3)[∂][Y₂]
- ParamBox{Float64, :Z, FLevel{0}}(0.0)[∂][Z₂]
- ParamBox{Float64, :α, FLevel{0}}(2.5)[∂][α₁]
- ParamBox{Float64, :d, FLevel{0}}(0.5)[∂][d₁]
+10-element Vector{ParamBox{Float64, V, typeof(itself)} where V}:
+ ParamBox{Float64, :X, iT}(0.0)[∂][X₁]
+ ParamBox{Float64, :Y, iT}(0.1)[∂][Y₁]
+ ParamBox{Float64, :Z, iT}(0.0)[∂][Z₁]
+ ParamBox{Float64, :α, iT}(2.5)[∂][α₁]
+ ParamBox{Float64, :d, iT}(0.5)[∂][d₁]
+ ParamBox{Float64, :X, iT}(1.4)[∂][X₂]
+ ParamBox{Float64, :Y, iT}(0.3)[∂][Y₂]
+ ParamBox{Float64, :Z, iT}(0.0)[∂][Z₂]
+ ParamBox{Float64, :α, iT}(2.5)[∂][α₁]
+ ParamBox{Float64, :d, iT}(0.5)[∂][d₁]
 ```
 
 `markParams!` marks all the parameters of a given basis set. Even though `bs7` has two `GaussFunc`s as basis functions, overall it only has one unique coefficient exponent ``\alpha_1`` and one unique contraction coefficient ``d_1`` besides the center coordinates.
@@ -227,7 +227,7 @@ Another control the user have on the parameters in Quiqbox is through a `ParamBo
 Such a mapping function is stored in the `map` field of the `ParamBox` (which normally is an ``R \to R`` mapping). The "output value" can be accessed through syntax `()`. In default, the input variable is mapped to an output variable that has the identical value:
 ```jldoctest myLabel2
 julia> pb1 = gf4.xpn
-ParamBox{Float64, :α, FLevel{0}}(2.5)[∂][α₁]
+ParamBox{Float64, :α, iT}(2.5)[∂][α₁]
 
 julia> pb1.map
 itself (generic function with 1 method)

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -14,6 +14,8 @@ abstract type QuiqboxContainer{T} <: AbstractQuiqboxContainer end
 abstract type MetaParam{T} <: MetaParameter end
 
 
+abstract type FLevel{L} <: MetaParam{FLevel} end
+
 abstract type CompositeFunction{F2, F1} <: StructFunction{F1} end
 
 abstract type QuiqboxVariableBox{T} <: QuiqboxContainer{T} end
@@ -71,6 +73,8 @@ abstract type CompositeGTBasisFuncs{NumberT, D, NofLinearlyCombinedBasis, Orbita
 
 abstract type FloatingGTBasisFuncs{NumberT, D, 𝑙, GaussFuncN, PointT, OrbitalN} <: CompositeGTBasisFuncs{NumberT, D, 1, OrbitalN} end
 
+
+const IF = Union{itselfT, typeof(Base.identity)}
 
 const CGTBasisFuncsON{ON} = CompositeGTBasisFuncs{<:Any, <:Any, <:Any, ON}
 const CGTBasisFuncs1O{T, D, BN} = CompositeGTBasisFuncs{T, D, BN, 1}

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -15,12 +15,11 @@ abstract type MetaParam{T} <: MetaParameter end
 
 
 abstract type CompositeFunction{F2, F1} <: StructFunction{F1} end
-abstract type DressedFunction{FL, F} <: StructFunction{F} end
 
 abstract type QuiqboxVariableBox{T} <: QuiqboxContainer{T} end
 
 
-abstract type ParameterizedFunction{P, F} <: CompositeFunction{P, F} end
+abstract type ParameterizedFunction{P, F, T} <: CompositeFunction{P, F} end
 
 abstract type QuiqboxParameter{T, ParameterT, ContainerT} <: QuiqboxVariableBox{T} end
 abstract type QuiqboxDataBox{T} <: QuiqboxVariableBox{T} end

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -14,14 +14,12 @@ abstract type QuiqboxContainer{T} <: AbstractQuiqboxContainer end
 abstract type MetaParam{T} <: MetaParameter end
 
 
-abstract type FLevel{L} <: MetaParam{FLevel} end
-
-abstract type CompositeFunction{F2, F1} <: StructFunction{F1} end
+abstract type CompositeFunction{F1, F2} <: StructFunction{F1} end
 
 abstract type QuiqboxVariableBox{T} <: QuiqboxContainer{T} end
 
 
-abstract type ParameterizedFunction{P, F, T} <: CompositeFunction{P, F} end
+abstract type ChainedFunction{F, O, C} <: CompositeFunction{F, C} end
 
 abstract type QuiqboxParameter{T, ParameterT, ContainerT} <: QuiqboxVariableBox{T} end
 abstract type QuiqboxDataBox{T} <: QuiqboxVariableBox{T} end
@@ -73,8 +71,6 @@ abstract type CompositeGTBasisFuncs{NumberT, D, NofLinearlyCombinedBasis, Orbita
 
 abstract type FloatingGTBasisFuncs{NumberT, D, 𝑙, GaussFuncN, PointT, OrbitalN} <: CompositeGTBasisFuncs{NumberT, D, 1, OrbitalN} end
 
-
-const IF = Union{itselfT, typeof(Base.identity)}
 
 const CGTBasisFuncsON{ON} = CompositeGTBasisFuncs{<:Any, <:Any, <:Any, ON}
 const CGTBasisFuncs1O{T, D, BN} = CompositeGTBasisFuncs{T, D, BN, 1}

--- a/src/Basis.jl
+++ b/src/Basis.jl
@@ -188,13 +188,13 @@ $( SpatialPoint(ParamBox.((1.0, 2.0, 3.0), SpatialParamSyms)) )
 julia> v2 = [fill(1.0), 2.0, 3.0];
 
 julia> p2 = genSpatialPoint(v2); p2[1]
-ParamBox{Float64, :X, $(IL)}(1.0)[∂][X]
+ParamBox{Float64, :X, iT}(1.0)[∂][X]
 
 julia> v2[1][] = 1.2
 1.2
 
 julia> p2[1]
-ParamBox{Float64, :X, $(IL)}(1.2)[∂][X]
+ParamBox{Float64, :X, iT}(1.2)[∂][X]
 ```
 """
 genSpatialPoint(v::AbstractVector) = genSpatialPoint(Tuple(v))
@@ -233,17 +233,17 @@ Convert a `ParamBox` to the `compIndex` th component of a `SpatialPoint`.
 
 ```jldoctest; setup = :(push!(LOAD_PATH, "../../src/"); using Quiqbox)
 julia> genSpatialPoint(1.2, 1)
-ParamBox{Float64, :X, $(IL)}(1.2)[∂][X]
+ParamBox{Float64, :X, iT}(1.2)[∂][X]
 
 julia> pointY1 = fill(2.0);
 
 julia> Y1 = genSpatialPoint(pointY1, 2)
-ParamBox{Float64, :Y, $(IL)}(2.0)[∂][Y]
+ParamBox{Float64, :Y, iT}(2.0)[∂][Y]
 
 julia> pointY1[] = 1.5;
 
 julia> Y1
-ParamBox{Float64, :Y, $(IL)}(1.5)[∂][Y]
+ParamBox{Float64, :Y, iT}(1.5)[∂][Y]
 ```
 """
 genSpatialPoint(compData::Pair{Array{T, 0}, Symbol}, compIndex::Int, 
@@ -1839,8 +1839,8 @@ value(s) of the [`ParamBox`](@ref)(s) stored in `b` will be copied, i.e.,
 ≡≡≡ Example(s) ≡≡≡
 
 ```jldoctest; setup = :(push!(LOAD_PATH, "../../src/"); using Quiqbox)
-julia> e = genExponent(3.0, x->x^2)
-$( genExponent(3.0, x->x^2) )
+julia> f(x)=x^2; e = genExponent(3.0, f)
+ParamBox{Float64, :α, typeof(f)}(3.0)[∂][x_α]
 
 julia> c = genContraction(2.0)
 $( genContraction(2.0) )

--- a/src/Basis.jl
+++ b/src/Basis.jl
@@ -50,18 +50,18 @@ GaussFunc(genExponent(e), genContraction(d))
 """
 
     genExponent(e::T, mapFunction::Function=$(itself); 
-                canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(FI), false, true), 
+                canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(IL), false, true), 
                 inSym::Symbol=$(xpnIVsym)) where {T<:AbstractFloat} -> 
     ParamBox{T, :$(xpnSym)}
 
     genExponent(e::Array{T, 0}, mapFunction::Function=$(itself); 
-                canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(FI), false, true), 
+                canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(IL), false, true), 
                 inSym::Symbol=$(xpnIVsym)) where {T<:AbstractFloat} -> 
     ParamBox{T, :$(xpnSym)}
 
     genExponent(eData::Pair{Array{T, 0}, Symbol}, 
                 mapFunction::Function=$(itself); 
-                canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(FI), false, true)) where 
+                canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(IL), false, true)) where 
                {T<:AbstractFloat} -> 
     ParamBox{T, :$(xpnSym)}
 
@@ -70,17 +70,17 @@ Construct an exponent coefficient given a value or variable (with its symbol).
 [`ParamBox`](@ref).
 """
 genExponent(eData::Pair{Array{T, 0}, Symbol}, mapFunction::Function=itself; 
-            canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true)) where 
+            canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true)) where 
            {T<:AbstractFloat} = 
 ParamBox(Val(xpnSym), mapFunction, eData, genIndex(nothing), fill(canDiff))
 
 genExponent(e::Array{T, 0}, mapFunction::Function=itself; 
-            canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true), 
+            canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true), 
             inSym::Symbol=xpnIVsym) where {T<:AbstractFloat} = 
 genExponent(e=>inSym, mapFunction; canDiff)
 
 genExponent(e::AbstractFloat, mapFunction::Function=itself; 
-            canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true), 
+            canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true), 
             inSym::Symbol=xpnIVsym) = 
 genExponent(fill(e)=>inSym, mapFunction; canDiff)
 
@@ -96,18 +96,18 @@ genExponent(pb::ParamBox) = ParamBox(Val(xpnSym), pb, fill(pb.canDiff[]))
 """
 
     genContraction(d::T, mapFunction::Function=$(itself); 
-                   canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(FI), false, true), 
+                   canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(IL), false, true), 
                    inSym::Symbol=$(conIVsym)) where {T<:AbstractFloat} -> 
     ParamBox{T, :$(conSym)}
 
     genContraction(d::Array{T, 0}, mapFunction::Function=$(itself); 
-                   canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(FI), false, true), 
+                   canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(IL), false, true), 
                    inSym::Symbol=$(conIVsym)) where {T<:AbstractFloat} -> 
     ParamBox{T, :$(conSym)}
 
     genContraction(dData::Pair{Array{T, 0}, Symbol}, 
                    mapFunction::Function=$(itself); 
-                   canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(FI), false, true)) where 
+                   canDiff::Bool=ifelse($(FLevel)(mapFunction)==$(IL), false, true)) where 
                   {T<:AbstractFloat} -> 
     ParamBox{T, :$(conSym)}
 
@@ -117,17 +117,17 @@ Construct a contraction coefficient given a value or variable (with its symbol).
 """
 genContraction(dData::Pair{Array{T, 0}, Symbol}, 
                mapFunction::Function=itself; 
-               canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true)) where 
+               canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true)) where 
               {T<:AbstractFloat} = 
 ParamBox(Val(conSym), mapFunction, dData, genIndex(nothing), fill(canDiff))
 
 genContraction(d::Array{T, 0}, mapFunction::Function=itself; 
-               canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true), 
+               canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true), 
                inSym::Symbol=conIVsym) where {T<:AbstractFloat} = 
 genContraction(d=>inSym, mapFunction; canDiff)
 
 genContraction(d::AbstractFloat, mapFunction::Function=itself; 
-               canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true), 
+               canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true), 
                inSym::Symbol=conIVsym) = 
 genContraction(fill(d)=>inSym, mapFunction; canDiff)
 
@@ -188,13 +188,13 @@ $( SpatialPoint(ParamBox.((1.0, 2.0, 3.0), SpatialParamSyms)) )
 julia> v2 = [fill(1.0), 2.0, 3.0];
 
 julia> p2 = genSpatialPoint(v2); p2[1]
-ParamBox{Float64, :X, $(FI)}(1.0)[∂][X]
+ParamBox{Float64, :X, $(IL)}(1.0)[∂][X]
 
 julia> v2[1][] = 1.2
 1.2
 
 julia> p2[1]
-ParamBox{Float64, :X, $(FI)}(1.2)[∂][X]
+ParamBox{Float64, :X, $(IL)}(1.2)[∂][X]
 ```
 """
 genSpatialPoint(v::AbstractVector) = genSpatialPoint(Tuple(v))
@@ -205,19 +205,19 @@ genSpatialPoint.(v, Tuple([1:D;])) |> genSpatialPointCore
 
     genSpatialPoint(comp::T, compIndex::Int, 
                     mapFunction::Function=itself; 
-                    canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true), 
+                    canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true), 
                     inSym::Symbol=conIVsym) where {T<:AbstractFloat} -> 
     ParamBox{T}
 
     genSpatialPoint(comp::Array{T, 0}, compIndex::Int, 
                     mapFunction::Function=itself; 
-                    canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true), 
+                    canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true), 
                     inSym::Symbol=conIVsym) where {T<:AbstractFloat} -> 
     ParamBox{T}
 
     genSpatialPoint(compData::Pair{Array{T, 0}, Symbol}, compIndex::Int, 
                     mapFunction::Function=itself; 
-                    canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true)) -> 
+                    canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true)) -> 
     ParamBox{T}
 
 Construct a [`ParamBox`](@ref) as the `compIndex` th component of a [`SpatialPoint`](@ref) 
@@ -233,35 +233,35 @@ Convert a `ParamBox` to the `compIndex` th component of a `SpatialPoint`.
 
 ```jldoctest; setup = :(push!(LOAD_PATH, "../../src/"); using Quiqbox)
 julia> genSpatialPoint(1.2, 1)
-ParamBox{Float64, :X, $(FI)}(1.2)[∂][X]
+ParamBox{Float64, :X, $(IL)}(1.2)[∂][X]
 
 julia> pointY1 = fill(2.0);
 
 julia> Y1 = genSpatialPoint(pointY1, 2)
-ParamBox{Float64, :Y, $(FI)}(2.0)[∂][Y]
+ParamBox{Float64, :Y, $(IL)}(2.0)[∂][Y]
 
 julia> pointY1[] = 1.5;
 
 julia> Y1
-ParamBox{Float64, :Y, $(FI)}(1.5)[∂][Y]
+ParamBox{Float64, :Y, $(IL)}(1.5)[∂][Y]
 ```
 """
 genSpatialPoint(compData::Pair{Array{T, 0}, Symbol}, compIndex::Int, 
                 mapFunction::Function=itself; 
-                canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true)) where 
+                canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true)) where 
                {T<:AbstractFloat} = 
 ParamBox(Val(SpatialParamSyms[compIndex]), mapFunction, compData, genIndex(nothing), 
          fill(canDiff))
 
 genSpatialPoint(comp::Array{T, 0}, compIndex::Int, 
                 mapFunction::Function=itself; 
-                canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true), 
+                canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true), 
                 inSym::Symbol=conIVsym) where {T<:AbstractFloat} = 
 genSpatialPoint(comp=>inSym, compIndex, mapFunction; canDiff)
 
 genSpatialPoint(comp::AbstractFloat, compIndex::Int, 
                 mapFunction::Function=itself; 
-                canDiff::Bool=ifelse(FLevel(mapFunction)==FI, false, true), 
+                canDiff::Bool=ifelse(FLevel(mapFunction)==IL, false, true), 
                 inSym::Symbol=conIVsym) = 
 genSpatialPoint(fill(comp)=>inSym, compIndex, mapFunction; canDiff)
 

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -4,12 +4,12 @@ function makeGridFuncsCore(nG::Int)
     if iszero(nG)
         [itself]
     else
-        Pf.((0:nG) .- 0.5nG, itself)
+        Pf.(itself, (0:nG) .- 0.5nG)
     end
 end
 
-makeGridFuncs(c, f::F) where {F<:Function} = Sf(c, f)
-makeGridFuncs(_, ::itselfT) = itself
+makeGridFuncs(f::F, c) where {F<:Function} = Sf(f, c)
+makeGridFuncs(::itselfT, _) = itself
 
 makeGridPBoxData(cenCompData::Array{T, 0}, spacingData::Array{T, 0}, nG::Int) where {T} = 
 ifelse(nG>0, spacingData, cenCompData)
@@ -87,7 +87,7 @@ struct GridBox{T, D, NP, GPT<:SpatialPoint{T, D}} <: SpatialStructure{T, D}
         spacing = fillObj.(spacing)
         data = makeGridPBoxData.(fill.(center), spacing, nGrids)
         for (n, i) in enumerate( CartesianIndices(nGrids .+ 1) )
-            fs = makeGridFuncs.(center, [funcs[j][k] for (j, k) in enumerate(i|>Tuple)])
+            fs = makeGridFuncs.([funcs[j][k] for (j, k) in enumerate(i|>Tuple)], center)
             p = broadcast((a, b, c, d, canDiff, index) -> 
                           ParamBox(a, b, c, d; canDiff, index), 
                           data, oVsym, fs, iVsym, canDiff, index)|>Tuple

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -1,21 +1,11 @@
 export gridBoxCoords, GridBox, gridCoordOf
 
 function makeGridFuncsCore(nG::Int)
-    res = Array{Function}(undef, nG+1)
-    if nG == 0
-        res[] = itself
+    if iszero(nG)
+        [itself]
     else
-        for i = 0:nG
-            funcName = "G$(nG)" * numToSups(i)
-            funcSym = Symbol(funcName)
-            res[i+1] = if isdefined(Quiqbox, funcSym)
-                getproperty(Quiqbox, funcSym)
-            else
-                renameFunc(funcName, L -> (i - 0.5nG)*L)
-            end
-        end
+        Pf.((0:nG) .- 0.5nG, itself)
     end
-    res
 end
 
 makeGridFuncs(c, f::F) where {F<:Function} = Sf(c, f)

--- a/src/Box.jl
+++ b/src/Box.jl
@@ -4,12 +4,12 @@ function makeGridFuncsCore(nG::Int)
     if iszero(nG)
         [itself]
     else
-        Pf.(itself, (0:nG) .- 0.5nG)
+        PF.(itself, *, (0:nG) .- 0.5nG)
     end
 end
 
-makeGridFuncs(f::F, c) where {F<:Function} = Sf(f, c)
-makeGridFuncs(::itselfT, _) = itself
+makeGridFuncs(f::F, c) where {F<:Function} = PF(f, +, c)
+makeGridFuncs(::iT, _) = itself
 
 makeGridPBoxData(cenCompData::Array{T, 0}, spacingData::Array{T, 0}, nG::Int) where {T} = 
 ifelse(nG>0, spacingData, cenCompData)

--- a/src/Differentiation.jl
+++ b/src/Differentiation.jl
@@ -204,7 +204,7 @@ end
 
 𝑑f(::Type{FL}, f::F, x::T) where {FL<:FLevel, F<:Function, T} = ForwardDerivative(f, x)
 
-𝑑f(::Type{FI}, ::Function, ::T) where {T} = T(1.0)
+𝑑f(::Type{IL}, ::Function, ::T) where {T} = T(1.0)
 
 ∂SGFcore(::Val{xpnSym}, sgf::FGTBasisFuncs1O{T, 3, 𝑙, 1}, c::T=T(1)) where {T, 𝑙} = 
 hasNormFactor(sgf) ? ∂SGF∂xpn2(sgf, c) : ∂SGF∂xpn1(sgf, c)

--- a/src/Differentiation.jl
+++ b/src/Differentiation.jl
@@ -202,9 +202,9 @@ function gradOfHFenergy(par::AbstractVector{<:ParamBox{T}},
 end
 
 
-𝑑f(::Type{FL}, f::F, x::T) where {FL<:FLevel, F<:Function, T} = ForwardDerivative(f, x)
+𝑑f(f::Function, x) = ForwardDerivative(f, x)
 
-𝑑f(::Type{IL}, ::Function, ::T) where {T} = T(1.0)
+𝑑f(::DI, ::T) where {T} = T(1.0)
 
 ∂SGFcore(::Val{xpnSym}, sgf::FGTBasisFuncs1O{T, 3, 𝑙, 1}, c::T=T(1)) where {T, 𝑙} = 
 hasNormFactor(sgf) ? ∂SGF∂xpn2(sgf, c) : ∂SGF∂xpn1(sgf, c)
@@ -244,11 +244,11 @@ end
 
 const sgfSample = genBasisFunc([0.0, 0.0, 0.0], (2.0, 1.0))
 
-const cxIndex = findfirst(x->getTypeParams(x)[2]==cxSym, sgfSample.param)
-const cyIndex = findfirst(x->getTypeParams(x)[2]==cySym, sgfSample.param)
-const czIndex = findfirst(x->getTypeParams(x)[2]==czSym, sgfSample.param)
-const xpnIndex = findfirst(x->getTypeParams(x)[2]==xpnSym, sgfSample.param)
-const conIndex = findfirst(x->getTypeParams(x)[2]==conSym, sgfSample.param)
+const cxIndex  = findfirst(x -> outSymOf(x) ==  cxSym, sgfSample.param)
+const cyIndex  = findfirst(x -> outSymOf(x) ==  cySym, sgfSample.param)
+const czIndex  = findfirst(x -> outSymOf(x) ==  czSym, sgfSample.param)
+const xpnIndex = findfirst(x -> outSymOf(x) == xpnSym, sgfSample.param)
+const conIndex = findfirst(x -> outSymOf(x) == conSym, sgfSample.param)
 
 getVpar(sgf::FGTBasisFuncs1O{<:Any, <:Any, <:Any, 1}, ::Val{cxSym}) = sgf.param[cxIndex]
 getVpar(sgf::FGTBasisFuncs1O{<:Any, <:Any, <:Any, 1}, ::Val{cySym}) = sgf.param[cyIndex]
@@ -263,12 +263,11 @@ function ∂BasisCore1(par::ParamBox{T, V, FL}, sgf::FGTBasisFuncs1O{T, D, <:Any
                     {T, FL, V, D}
     mapreduce(+, sgf.param) do fPar
         c = if isDiffParam(fPar) && compareParamBoxCore1(fPar, par)
-            _, V2, FL2 = getTypeParams(fPar)
-            𝑑f(FL2, fPar.map, fPar[])
+            𝑑f(fPar.map, fPar[])
         else
             0
         end
-        iszero(c) ? EmptyBasisFunc{T, D}() : ∂SGFcore(Val(V2), sgf, c)
+        iszero(c) ? EmptyBasisFunc{T, D}() : ∂SGFcore(Val(outSymOf(fPar)), sgf, c)
     end
 end
 

--- a/src/HartreeFock.jl
+++ b/src/HartreeFock.jl
@@ -721,8 +721,8 @@ function runHFcore(::Val{HFT},
     vars = initializeSCF(Val(HFT), Hcore, HeeI, C0, N)
     Etots = vars[1].shared.Etots
     oscThreshold = scfConfig.oscillateThreshold
-    printInfo && println(rpad(HFT, 8)*rpad(" | Initial Gauss", 18), 
-                         "E = ", alignNumSign(Etots[end], roundDigits=getAtolDigits(T2)))
+    printInfo && println(rpad(HFT, 9)*rpad("| Initial Gauss", 16), 
+                         "| E = ", alignNumSign(Etots[end], roundDigits=getAtolDigits(T2)))
     isConverged = true
     i = 0
     ΔE = 0.0
@@ -764,8 +764,8 @@ function runHFcore(::Val{HFT},
             end
 
             printInfo && (i % floor(log(4, i) + 1) == 0 || i == maxStep) && 
-            println(rpad("Step $i", 9), rpad("| #$l ($(m))", 17), 
-                    "E = ", alignNumSign(Etots[end], roundDigits=getAtolDigits(T2)))
+            println(rpad("Step $i", 9), rpad("| #$l ($(m))", 16), 
+                    "| E = ", alignNumSign(Etots[end], roundDigits=getAtolDigits(T2)))
 
             isConverged && abs(ΔE) <= breakPoint && break
         end
@@ -781,7 +781,11 @@ end
 
 function terminateSCF(i, vars, method, printInfo)
     popHFtempVars!(vars)
-    printInfo && println("Early termination of ", method, " due to the poor performance.")
+    if printInfo
+        print("Early termination of ")
+        printstyled(method, underline=true)
+        println(" due to its poor performance.")
+    end
     i-1
 end
 

--- a/src/HartreeFock.jl
+++ b/src/HartreeFock.jl
@@ -487,10 +487,10 @@ struct InitialC{T<:Number, HFT, F<:Function}
     InitialC(::Val{HFT}, f::F, ::Type{T}) where {HFT, F, T} = new{T, HFT, F}((), f)
 
     InitialC(::Val{:RHF}, C0::NTuple{1, AbstractMatrix{T}}) where {T} = 
-    new{T, :RHF, itselfT}(C0, itself)
+    new{T, :RHF, iT}(C0, itself)
 
     InitialC(::Val{:UHF}, C0::NTuple{2, AbstractMatrix{T}}) where {T} = 
-    new{T, :UHF, itselfT}(C0, itself)
+    new{T, :UHF, iT}(C0, itself)
 end
 
 const defaultHFconfigPars = [:RHF, :SAD, defaultSCFconfig, 100, true]
@@ -546,12 +546,12 @@ mutable struct HFconfig{T1, HFT, F, T2, L} <: ConfigBox{T1, HFconfig, HFT}
     HFconfig(::Val{:UHF}, 
              a2::NTuple{2, AbstractMatrix{T1}}, a3::SCFconfig{T2, L}, a4, a5) where 
             {T1, T2, L} = 
-    new{T1, :UHF, itselfT, T2, L}(Val(:UHF), InitialC(Val(:UHF), a2), a3, a4, a5)
+    new{T1, :UHF, iT, T2, L}(Val(:UHF), InitialC(Val(:UHF), a2), a3, a4, a5)
 
     HFconfig(::Val{:RHF}, 
              a2::Tuple{AbstractMatrix{T1}}, a3::SCFconfig{T2, L}, a4, a5) where 
             {T1, T2, L} = 
-    new{T1, :RHF, itselfT, T2, L}(Val(:RHF), InitialC(Val(:RHF), a2), a3, a4, a5)
+    new{T1, :RHF, iT, T2, L}(Val(:RHF), InitialC(Val(:RHF), a2), a3, a4, a5)
 
     function HFconfig(::Val{HFT}, a2::Val{CF}, a3::SCFconfig{T, L}, a4, a5) where 
                      {T, HFT, CF, L}

--- a/src/Integrals/Core.jl
+++ b/src/Integrals/Core.jl
@@ -986,16 +986,16 @@ const IndexABXYbools = Dict([Val{:acbc}, Val{:abbc}, Val{:abcd}] .=>
                              (j,k,_) -> (Val(false), Val(false), k==j, Val(false)), 
                              (_,_,_) ->  Val(false)])
 
-function getCompositeIntCore(::Val{T}, ::Val{D}, ::Val{BL}, ::IT, ∫::F, 
+function getCompositeIntCore(::Val{T}, ::Val{D}, ::Val{BL}, ::IDV, ∫::F, 
                              bs::NTuple{4, SpatialBasis{T, D}}, optArgs...) where 
-                            {T, D, BL, IT<:Union{Val{:acbc}, Val{:abbc}, Val{:abcd}}, 
+                            {T, D, BL, IDV<:Union{Val{:acbc}, Val{:abbc}, Val{:abcd}}, 
                              F<:Function}
     bfsI, bfsJ, bfsK, bfsL = bs = getBFs.(Val(BL), bs)
     ON1, ON2, ON3, ON4 = length.(bs)
     res = zeros(T, ON1, ON2, ON3, ON4)
     for (l, bfl) in enumerate(bfsL), (k, bfk) in enumerate(bfsK), 
         (j, bfj) in enumerate(bfsJ), (i, bfi) in enumerate(bfsI)
-        bl = IndexABXYbools[IT](j,k,l)
+        bl = IndexABXYbools[IDV](j,k,l)
         res[i,j,k,l] = getCompositeInt(∫, bl, (bfi, bfj, bfk, bfl), optArgs...)
     end
     res

--- a/src/Mapping.jl
+++ b/src/Mapping.jl
@@ -9,18 +9,14 @@ end
 (::DressedItself)(x) = itself(x)
 (di::DressedItself)() = di.f
 
-
-struct FLevel{L} <: MetaParam{FLevel} end
-
-FLevel(::Type{itselfT}) = FLevel{0}
-FLevel(::Type{typeof(Base.identity)}) = FLevel{0}
+FLevel(::Type{<:IF}) = FLevel{0}
 FLevel(::Type{<:Function}) = FLevel{1}
 FLevel(::Type{<:DressedItself{L}}) where {L} = FLevel{L}
 FLevel(::Type{<:CompositeFunction{F2, F1}}) where {F1, F2} = 
 FLevel{getFLevel(F2)+getFLevel(F1)}
 FLevel(::F) where {F<:Function} = FLevel(F)
 
-const FI = FLevel(itself)
+const IL = FLevel(itself)
 
 getFLevel(::Type{FLevel{L}}) where {L} = L
 getFLevel(::Type{F}) where {F<:Function} = (getFLevel∘FLevel)(F)

--- a/src/Mapping.jl
+++ b/src/Mapping.jl
@@ -1,11 +1,21 @@
 export FLevel
 
+struct DressedItself{L, F<:Function} <: StructFunction{F}
+    f::F
+    DressedItself(f::F) where {F} = new{getFLevel(F), F}(f)
+    DressedItself(di::DressedItself{L, F}) where {L, F} = new{L, F}(di.f)
+end
+
+(::DressedItself)(x) = itself(x)
+(di::DressedItself)() = di.f
+
+
 struct FLevel{L} <: MetaParam{FLevel} end
 
 FLevel(::Type{itselfT}) = FLevel{0}
 FLevel(::Type{typeof(Base.identity)}) = FLevel{0}
 FLevel(::Type{<:Function}) = FLevel{1}
-FLevel(::Type{<:DressedFunction{L}}) where {L} = FLevel{L}
+FLevel(::Type{<:DressedItself{L}}) where {L} = FLevel{L}
 FLevel(::Type{<:CompositeFunction{F2, F1}}) where {F1, F2} = 
 FLevel{getFLevel(F2)+getFLevel(F1)}
 FLevel(::F) where {F<:Function} = FLevel(F)
@@ -33,84 +43,67 @@ end
 Absolute(f) = Layered(abs, f)
 
 
-struct DressedItself{L, F<:Function} <: DressedFunction{L, F}
-    f::F
-    DressedItself(f::F) where {F} = new{getFLevel(F), F}(f)
-    DressedItself(di::DressedItself{L, F}) where {L, F} = new{L, F}(di.f)
-end
-
-(::DressedItself)(x) = itself(x)
-(di::DressedItself)() = di.f
-
-
 # Product Function
-struct Pf{T, F<:Function} <: ParameterizedFunction{Pf, F}
-    c::T
+struct Pf{F<:Function, T} <: ParameterizedFunction{Pf, F, T} # Pf{T} ?
     f::F
+    c::T
 end
-Pf(c, f::Pf{T, F}) where {T, F<:Function} = Pf{T, F}(f.c*T(c), f.f)
-(f::Pf)(x::T) where {T} = f.c * f.f(x)
+Pf(f::Pf{F, T}, c) where {F<:Function, T} = Pf{F, T}(f.f, f.c*T(c))
+(f::Pf)(x::T) where {T} = f.f(x)*f.c
 
 
 # Sum Function
-struct Sf{T, F<:Function} <: ParameterizedFunction{Sf, F}
-    c::T
+struct Sf{F<:Function, T} <: ParameterizedFunction{Sf, F, T}
     f::F
+    c::T
 end
-Sf(c, f::Sf{T, F}) where {T, F<:Function} = Sf{T, F}(f.c+T(c), f.f)
-(f::Sf)(x::T) where {T} = f.c + f.f(x)
+Sf(f::Sf{F, T}, c) where {F<:Function, T} = Sf{F, T}(f.f, f.c+T(c))
+(f::Sf)(x::T) where {T} = f.f(x)+f.c
 
 # Exponent Function
-struct Xf{P, F<:Function} <: ParameterizedFunction{Xf, F}
+struct Xf{F<:Function, T} <: ParameterizedFunction{Xf, F, T}
     f::F
-    Xf(P::Int, f::F) where {F<:Function} = new{P, F}(f)
+    c::T
 end
-Xf(PN::Int, f::Xf{P, F}) where {P, F<:Function} = Xf(P+PN, f.f)
-(f::Xf{P})(x) where {P} = f.f(x)^P
+Xf(f::Xf{F, T}, c) where {F<:Function, T} = Xf{F, T}(f.f, f.c*T(c))
+(f::Xf)(x::T) where {T} = f.f(x)^f.c
 
 
-function combineParFunc(::typeof(+), pf1::F1, pf2::F2) where 
-                       {F, F1<:ParameterizedFunction{Pf, F}, 
-                           F2<:ParameterizedFunction{Pf, F}}
+function combineParFunc(::typeof(+), pf1::Pf{F}, pf2::Pf{F}) where {F}
     c = (pf1.c + pf2.c)
-    isone(c) ? pf1.f : Pf(c, pf1.f)
+    isone(c) ? pf1.f : Pf(pf1.f, c)
 end
 
-function combineParFunc(::typeof(+), pf1::F1, pf2::F2) where 
-              {F, F1<:ParameterizedFunction{Sf, F}, F2<:ParameterizedFunction{Sf, F}}
+function combineParFunc(::typeof(+), pf1::Sf{F}, pf2::Sf{F}) where {F}
     c = pf1.c + pf2.c
-    iszero(c) ? Pf(2, pf1.f) : Sf(c, Pf(2, pf1.f))
+    iszero(c) ? Pf(pf1.f, 2) : Sf(f(pf1.f, 2), c)
 end
 
-function combineParFunc(::typeof(+), pf1::F1, pf2::F2) where 
-              {F, F1<:ParameterizedFunction{Pf, F}, F2<:ParameterizedFunction{Sf, F}}
+function combineParFunc(::typeof(+), pf1::Pf{F}, pf2::Sf{F}) where {F}
     c = pf1.c + 1
-    isone(c) ? Sf(pf2.c, pf1.f) : Sf(pf2.c, Pf(c, pf1.f))
+    isone(c) ? Sf(pf1.f, pf2.c) : Sf(Pf(pf1.f, c), pf2.c)
 end
 
-combineParFunc(::typeof(+), pf1::F1, pf2::F2) where 
-              {F, F1<:ParameterizedFunction{Sf, F}, F2<:ParameterizedFunction{Pf, F}} = 
+combineParFunc(::typeof(+), pf1::Sf{F}, pf2::Pf{F}) where {F} = 
 combineParFunc(+, pf2, pf1)
 
 combineParFunc(op::Function, pf1::Function, pf2::Function) = x->op(pf1(x), pf2(x))
 
-function combineParFunc(::typeof(*), pf1::F1, pf2::F2) where 
-              {F, F1<:ParameterizedFunction{Pf, F}, F2<:ParameterizedFunction{Pf, F}}
+function combineParFunc(::typeof(*), pf1::Pf{F}, pf2::Pf{F}) where {F}
     c = pf1.c * pf2.c
-    isone(c) ? Xf(2, pf1.f) : Pf(c, Xf(2, pf1.f))
+    isone(c) ? Xf(pf1.f, 2) : Pf(Xf(pf1.f, 2), c)
 end
 
-function combineParFunc(::typeof(*), pf1::Xf{P1, F}, pf2::Xf{P2, F}) where {P1, P2, F}
-    P = P1 + P2
-    iszero(P) ? (_->1) : (isone(P) ? pf1.f : Xf(P, pf1.f))
+function combineParFunc(::typeof(*), pf1::Xf{F}, pf2::Xf{F}) where {F}
+    c = pf1.c + pf2.c
+    iszero(c) ? (_->1) : (isone(c) ? pf1.f : Xf(pf1.f, c))
 end
 
-function combineParFunc(::typeof(*), pf1::Xf{P, F}, pf2::Pf{<:Any, F}) where {P, F}
-    P2 = P + 1
-    f = iszero(P2) ? (_->1) : (isone(P2) ? pf1.f : Xf(P2, pf1.f))
-    Pf(pf2.c, f)
+function combineParFunc(::typeof(*), pf1::Xf{F}, pf2::Pf{F}) where {F}
+    c = pf1.c + 1
+    f = iszero(c) ? (_->1) : (isone(c) ? pf1.f : Xf(pf1.f, c))
+    Pf(f, pf2.c)
 end
 
-combineParFunc(::typeof(*), pf1::F1, pf2::F2) where 
-              {F, F1<:ParameterizedFunction{Sf, F}, F2<:ParameterizedFunction{Pf, F}} = 
+combineParFunc(::typeof(*), pf1::Sf{F}, pf2::Pf{F}) where {F} = 
 combineParFunc(+, pf2, pf1)

--- a/src/Optimization.jl
+++ b/src/Optimization.jl
@@ -280,7 +280,7 @@ function makeAbsLayerForXpnParams(pbs, bs, onlyForNegXpn::Bool=false;
                                                                true : pb.canDiff[])) )
     absXpn2 = if tryJustFlipNegSign
         function (pb::ParamBox)
-            if getTypeParams(pb)[end] == FI || pb.map isa DressedItself
+            if getTypeParams(pb)[end] == IL || pb.map isa DressedItself
                 pb[] *= sign(pb[])
                 pb
             else

--- a/src/Overload.jl
+++ b/src/Overload.jl
@@ -4,7 +4,7 @@ import Base: ==
 ==(pb1::ParamBox, pb2::ParamBox) = (pb1.data == pb2.data && 
                                     isDiffParam(pb1) == isDiffParam(pb2) && 
                                     pb1.index[] == pb2.index[] && 
-                                    pb1.map == pb2.map)
+                                    hasEqual(pb1.map, pb2.map))
 
 ==(cp1::SpatialPoint, cp2::SpatialPoint) = (cp1.param == cp2.param)
 ==(t1::LTuple, t2::LTuple) = (t1.tuple == t2.tuple)

--- a/src/Overload.jl
+++ b/src/Overload.jl
@@ -4,7 +4,7 @@ import Base: ==
 ==(pb1::ParamBox, pb2::ParamBox) = (pb1.data == pb2.data && 
                                     isDiffParam(pb1) == isDiffParam(pb2) && 
                                     pb1.index[] == pb2.index[] && 
-                                    hasEqual(pb1.map, pb2.map))
+                                    pb1.map == pb2.map)
 
 ==(cp1::SpatialPoint, cp2::SpatialPoint) = (cp1.param == cp2.param)
 ==(t1::LTuple, t2::LTuple) = (t1.tuple == t2.tuple)
@@ -282,8 +282,8 @@ function hasBoolRelation(boolFunc::F,
             boolFunc(pb1.data[][begin], pb2.data[][begin]), 
 
             ( boolFunc(isDiffParam(pb1), isDiffParam(pb2)) && 
-                boolFunc(pb1.map, pb2.map) && 
-                boolFunc(pb1.data[][begin], pb2.data[][begin]) )
+              hasBoolRelation(boolFunc, pb1.map, pb2.map) && 
+              boolFunc(pb1.data[][begin], pb2.data[][begin]) )
         ), 
 
         false

--- a/src/Overload.jl
+++ b/src/Overload.jl
@@ -274,11 +274,11 @@ Base.broadcastable(sp::SpatialPoint) = Base.broadcastable(sp.param)
 # Quiqbox methods overload.
 ## Method overload of `hasBoolRelation` from Tools.jl.
 function hasBoolRelation(boolFunc::F, 
-                         pb1::ParamBox{<:Any, V1, F1}, pb2::ParamBox{<:Any, V2, F2}; 
+                         pb1::ParamBox{<:Any, V1, FL1}, pb2::ParamBox{<:Any, V2, FL2}; 
                          ignoreFunction::Bool=false, ignoreContainer::Bool=false, 
-                         kws...) where {F<:Function, V1, V2, F1, F2}
+                         kws...) where {F<:Function, V1, V2, FL1, FL2}
     ifelse(ignoreContainer || V1 == V2, 
-        ifelse((ignoreFunction || F1 == F2 == FI), 
+        ifelse((ignoreFunction || FL1 == FL2 == IL), 
             boolFunc(pb1.data[][begin], pb2.data[][begin]), 
 
             ( boolFunc(isDiffParam(pb1), isDiffParam(pb2)) && 

--- a/src/Overload.jl
+++ b/src/Overload.jl
@@ -4,7 +4,7 @@ import Base: ==
 ==(pb1::ParamBox, pb2::ParamBox) = (pb1.data == pb2.data && 
                                     isDiffParam(pb1) == isDiffParam(pb2) && 
                                     pb1.index[] == pb2.index[] && 
-                                    typeof(pb1.map) === typeof(pb2.map))
+                                    pb1.map == pb2.map)
 
 ==(cp1::SpatialPoint, cp2::SpatialPoint) = (cp1.param == cp2.param)
 ==(t1::LTuple, t2::LTuple) = (t1.tuple == t2.tuple)

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -67,10 +67,10 @@ respect to the input variable.
 
 ```jldoctest; setup = :(push!(LOAD_PATH, "../../src/"); using Quiqbox)
 julia> ParamBox(1.0)
-ParamBox{Float64, :undef, $(iT)}(1.0)[∂][undef]
+ParamBox{Float64, :undef, iT}(1.0)[∂][undef]
 
 julia> ParamBox(1.0, :a)
-ParamBox{Float64, :a, $(iT)}(1.0)[∂][a]
+ParamBox{Float64, :a, iT}(1.0)[∂][a]
 
 julia> ParamBox(1.0, :a, abs)
 ParamBox{Float64, :a, $(typeof(abs))}(1.0)[∂][x_a]

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -32,7 +32,7 @@ as a dependent variable or an independent variable.
     ParamBox(inVar::Union{T, Array{T, 0}}, outSym::Symbol=:undef, 
              inSym::Symbol=Symbol(IVsymSuffix, outSym); 
              index::Union{Int, Nothing}=nothing, canDiff::Bool=false) where {T} -> 
-    ParamBox{T, outSym, $(FI)}
+    ParamBox{T, outSym, $(IL)}
 
     ParamBox(inVar::Union{T, Array{T, 0}}, outSym::Symbol, mapFunction::Function, 
              inSym::Symbol=Symbol(IVsymSuffix, outSym); 
@@ -67,10 +67,10 @@ respect to the input variable.
 
 ```jldoctest; setup = :(push!(LOAD_PATH, "../../src/"); using Quiqbox)
 julia> ParamBox(1.0)
-ParamBox{Float64, :undef, $(FI)}(1.0)[∂][undef]
+ParamBox{Float64, :undef, $(IL)}(1.0)[∂][undef]
 
 julia> ParamBox(1.0, :a)
-ParamBox{Float64, :a, $(FI)}(1.0)[∂][a]
+ParamBox{Float64, :a, $(IL)}(1.0)[∂][a]
 
 julia> ParamBox(1.0, :a, abs)
 ParamBox{Float64, :a, $(FLevel(abs))}(1.0)[∂][x_a]
@@ -100,7 +100,7 @@ struct ParamBox{T, V, FL<:FLevel} <: DifferentiableParameter{T, ParamBox}
     end
 
     ParamBox{T, V}(data::Pair{Array{T, 0}, Symbol}, index, canDiff) where {T, V} = 
-    new{T, V, FI}(fill(data), itself, canDiff, index)
+    new{T, V, IL}(fill(data), itself, canDiff, index)
 end
 
 ParamBox(::Val{V}, mapFunction::F, data::Pair{Array{T, 0}, Symbol}, 
@@ -144,7 +144,7 @@ Return the value of the output variable of `pb`. Equivalent to `pb()`.
 """
 @inline outValOf(pb::ParamBox) = (pb.map∘inValOf)(pb)
 
-@inline outValOf(pb::ParamBox{<:Any, <:Any, FI}) = inValOf(pb)
+@inline outValOf(pb::ParamBox{<:Any, <:Any, IL}) = inValOf(pb)
 
 (pb::ParamBox)() = outValOf(pb)
 # (pb::ParamBox)() = Base.invokelatest(pb.map, pb.data[][begin][])::Float64
@@ -229,7 +229,7 @@ Return the mapping function of `pb`.
 
 """
 
-    outValCopy(pb::ParamBox{T, V}) where {T} -> ParamBox{T, V, $(FI)}
+    outValCopy(pb::ParamBox{T, V}) where {T} -> ParamBox{T, V, $(IL)}
 
 Return a new `ParamBox` of which the input variable's value is equal to the output 
 variable's value of `pb`.
@@ -327,8 +327,8 @@ compareParamBoxCore1(pb1::ParamBox, pb2::ParamBox) =
 compareParamBoxCore2(pb1::ParamBox{<:Any, V1}, pb2::ParamBox{<:Any, V2}) where {V1, V2} = 
 V1==V2 && compareParamBoxCore1(pb1, pb2) && hasIdentical(pb1.map, pb2.map)
 
-compareParamBoxCore2(pb1::ParamBox{<:Any, V1, FI}, 
-                     pb2::ParamBox{<:Any, V2, FI}) where {V1, V2} = 
+compareParamBoxCore2(pb1::ParamBox{<:Any, V1, IL}, 
+                     pb2::ParamBox{<:Any, V2, IL}) where {V1, V2} = 
 V1==V2 && compareParamBoxCore1(pb1, pb2)
 
 @inline function compareParamBox(pb1::ParamBox, pb2::ParamBox)

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -4,7 +4,7 @@ export ParamBox, inValOf, outValOf, inSymOf, outSymOf, isInSymEqual, isOutSymEqu
 
 """
 
-    ParamBox{T, V, FL<:FLevel} <: DifferentiableParameter{T, ParamBox}
+    ParamBox{T, V, F<:Function} <: DifferentiableParameter{T, ParamBox}
 
 Parameter container that can enable differentiation.
 
@@ -16,9 +16,9 @@ value of the input variable can be accessed by syntax `[]`; to modify it, for ex
 `pb::ParamBox{T}`, use the syntax `pb[] = newVal` where `newVal` is the new value that is 
 or can be converted into type `T`.
 
-`map::Function`: The mapping of the value of the input variable (i.e. the input value) 
-within the same domain (`.map(::T)->T`). The result (i.e., the value of the output 
-variable, or the "output value") can be accessed by syntax `()`.
+`map::Union{F, `[`DI`](@ref)`{F}}`: The mapping of the value of the input variable (i.e. 
+the input value) within the same domain (`.map(::T)->T`). The result (i.e., the value of 
+the output variable, or the "output value") can be accessed by syntax `()`.
 
 `canDiff::Array{Bool, 0}`: Indicator of whether the output variable is "marked" as 
 differentiable with respect to the input variable in the differentiation process. In other 
@@ -32,7 +32,7 @@ as a dependent variable or an independent variable.
     ParamBox(inVar::Union{T, Array{T, 0}}, outSym::Symbol=:undef, 
              inSym::Symbol=Symbol(IVsymSuffix, outSym); 
              index::Union{Int, Nothing}=nothing, canDiff::Bool=false) where {T} -> 
-    ParamBox{T, outSym, $(IL)}
+    ParamBox{T, outSym, $(iT)}
 
     ParamBox(inVar::Union{T, Array{T, 0}}, outSym::Symbol, mapFunction::Function, 
              inSym::Symbol=Symbol(IVsymSuffix, outSym); 
@@ -67,13 +67,13 @@ respect to the input variable.
 
 ```jldoctest; setup = :(push!(LOAD_PATH, "../../src/"); using Quiqbox)
 julia> ParamBox(1.0)
-ParamBox{Float64, :undef, $(IL)}(1.0)[∂][undef]
+ParamBox{Float64, :undef, $(iT)}(1.0)[∂][undef]
 
 julia> ParamBox(1.0, :a)
-ParamBox{Float64, :a, $(IL)}(1.0)[∂][a]
+ParamBox{Float64, :a, $(iT)}(1.0)[∂][a]
 
 julia> ParamBox(1.0, :a, abs)
-ParamBox{Float64, :a, $(FLevel(abs))}(1.0)[∂][x_a]
+ParamBox{Float64, :a, $(typeof(abs))}(1.0)[∂][x_a]
 ```
 
 **NOTE 1:** The rightmost "`[∂][IV]`" in the printed info indicates the differentiability 
@@ -87,27 +87,29 @@ parameter functional (e.g., the Hartree-Fock energy). However, the derivative wi
 to the stored input variable can also be computed to when the `ParamBox` is marked as 
 differentiable.
 """
-struct ParamBox{T, V, FL<:FLevel} <: DifferentiableParameter{T, ParamBox}
+struct ParamBox{T, V, F<:Function} <: DifferentiableParameter{T, ParamBox}
     data::Array{Pair{Array{T, 0}, Symbol}, 0}
-    map::Function
+    map::Union{F, DI{F}}
     canDiff::Array{Bool, 0}
     index::Array{<:Union{Int, Nothing}, 0}
 
     function ParamBox{T, V}(f::F, data::Pair{Array{T, 0}, Symbol}, index, canDiff) where 
                            {T, V, F<:Function}
-        @assert Base.return_types(f, (T,))[1] == T
-        new{T, V, FLevel(F)}(fill(data), f, canDiff, index)
+        Base.return_types(f, (T,))[1] == T || 
+        throw(AssertionError("The mapping function `$(f)` should return the same data " * 
+                             "type as it input."))
+        new{T, V, dressOf(F)}(fill(data), f, canDiff, index)
     end
 
     ParamBox{T, V}(data::Pair{Array{T, 0}, Symbol}, index, canDiff) where {T, V} = 
-    new{T, V, IL}(fill(data), itself, canDiff, index)
+    new{T, V, iT}(fill(data), itself, canDiff, index)
 end
 
 ParamBox(::Val{V}, mapFunction::F, data::Pair{Array{T, 0}, Symbol}, 
          index=genIndex(nothing), canDiff=fill(true)) where {V, F<:Function, T} = 
 ParamBox{T, V}(mapFunction, data, index, canDiff)
 
-ParamBox(::Val{V}, ::itselfT, data::Pair{Array{T, 0}, Symbol}, index=genIndex(nothing), 
+ParamBox(::Val{V}, ::IF, data::Pair{Array{T, 0}, Symbol}, index=genIndex(nothing), 
          canDiff=fill(false)) where {V, T} = 
 ParamBox{T, V}(data, index, canDiff)
 
@@ -143,8 +145,6 @@ Return the value of the input variable of `pb`. Equivalent to `pb[]`.
 Return the value of the output variable of `pb`. Equivalent to `pb()`.
 """
 @inline outValOf(pb::ParamBox) = (pb.map∘inValOf)(pb)
-
-@inline outValOf(pb::ParamBox{<:Any, <:Any, IL}) = inValOf(pb)
 
 (pb::ParamBox)() = outValOf(pb)
 # (pb::ParamBox)() = Base.invokelatest(pb.map, pb.data[][begin][])::Float64
@@ -206,7 +206,7 @@ function indVarOf(pb::ParamBox)
 end
 
 
-getTypeParams(::ParamBox{T, V, FL}) where {T, V, FL} = (T, V, FL)
+getTypeParams(::ParamBox{T, V, F}) where {T, V, F} = (T, V, F)
 
 
 """
@@ -229,7 +229,7 @@ Return the mapping function of `pb`.
 
 """
 
-    outValCopy(pb::ParamBox{T, V}) where {T} -> ParamBox{T, V, $(IL)}
+    outValCopy(pb::ParamBox{T, V}) where {T} -> ParamBox{T, V, $(iT)}
 
 Return a new `ParamBox` of which the input variable's value is equal to the output 
 variable's value of `pb`.
@@ -324,12 +324,15 @@ end
 compareParamBoxCore1(pb1::ParamBox, pb2::ParamBox) = 
 (pb1.data[][begin] === pb2.data[][begin])
 
-compareParamBoxCore2(pb1::ParamBox{<:Any, V1}, pb2::ParamBox{<:Any, V2}) where {V1, V2} = 
-V1==V2 && compareParamBoxCore1(pb1, pb2) && hasIdentical(pb1.map, pb2.map)
-
-compareParamBoxCore2(pb1::ParamBox{<:Any, V1, IL}, 
-                     pb2::ParamBox{<:Any, V2, IL}) where {V1, V2} = 
-V1==V2 && compareParamBoxCore1(pb1, pb2)
+function compareParamBoxCore2(pb1::ParamBox{<:Any, V1, F1}, 
+                              pb2::ParamBox{<:Any, V2, F2}) where {V1, V2, F1, F2}
+    bl = V1==V2 && compareParamBoxCore1(pb1, pb2)
+    if FLevel(F1) == FLevel(F2) == IL
+        bl
+    else
+        bl * hasIdentical(pb1.map, pb2.map)
+    end
+end
 
 @inline function compareParamBox(pb1::ParamBox, pb2::ParamBox)
     ifelse(( (bl=isDiffParam(pb1)) == isDiffParam(pb2) ),
@@ -347,7 +350,7 @@ end
 function addParamBox(pb1::ParamBox{T, V, FL1}, pb2::ParamBox{T, V, FL2}, 
                      roundAtol::Real=nearestHalfOf(getAtolVal(T))) where {T, V, FL1, FL2}
     if isDiffParam(pb1) && compareParamBox(pb1, pb2)
-        ParamBox(Val(V), combineParFunc(+, pb1.map, pb2.map), 
+        ParamBox(Val(V), combinePF(+, pb1.map, pb2.map), 
                  pb1.data[][begin]=>min(pb1.data[][end], pb2.data[][end]), 
                  genIndex(nothing), fill(true))
     else
@@ -360,7 +363,7 @@ end
 function mulParamBox(c::Number, pb::ParamBox{T, V}, 
                      roundAtol::Real=nearestHalfOf(getAtolVal(T))) where {T, V}
     if isDiffParam(pb)
-        mapFunc = Pf(pb.map, convert(T, roundToMultiOfStep(c, roundAtol)))
+        mapFunc = PF(pb.map, *, convert(T, roundToMultiOfStep(c, roundAtol)))
         ParamBox(Val(V), mapFunc, pb.data[], genIndex(nothing), fill(true))
     else
         ParamBox(Val(V), itself, 
@@ -371,7 +374,7 @@ end
 function mulParamBox(pb1::ParamBox{T, V, FL1}, pb2::ParamBox{T, V, FL2}, 
                      roundAtol::Real=nearestHalfOf(getAtolVal(T))) where {T, V, FL1, FL2}
     if isDiffParam(pb1) && compareParamBox(pb1, pb2)
-        ParamBox(Val(V), combineParFunc(*, pb1.map, pb2.map), 
+        ParamBox(Val(V), combinePF(*, pb1.map, pb2.map), 
                  pb1.data[][begin]=>min(pb1.data[][end], pb2.data[][end]), 
                  genIndex(nothing), fill(true))
     else

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -103,19 +103,9 @@ struct ParamBox{T, V, FL<:FLevel} <: DifferentiableParameter{T, ParamBox}
     new{T, V, FI}(fill(data), itself, canDiff, index)
 end
 
-function ParamBox(::Val{V}, mapFunction::F, data::Pair{Array{T, 0}, Symbol}, 
-                  index=genIndex(nothing), canDiff=fill(true)) where {V, F<:Function, T}
-    if getFLevel(F) != 0
-        fSym = mapFunction |> nameOf
-        fStr = fSym |> string
-        if startswith(fStr, '#')
-            idx = parse(Int, fStr[2:end])
-            fSym = Symbol("f_", V,  numToSubs(idx))
-            mapFunction = renameFunc(fSym, mapFunction)
-        end
-    end
-    ParamBox{T, V}(mapFunction, data, index, canDiff)
-end
+ParamBox(::Val{V}, mapFunction::F, data::Pair{Array{T, 0}, Symbol}, 
+         index=genIndex(nothing), canDiff=fill(true)) where {V, F<:Function, T} = 
+ParamBox{T, V}(mapFunction, data, index, canDiff)
 
 ParamBox(::Val{V}, ::itselfT, data::Pair{Array{T, 0}, Symbol}, index=genIndex(nothing), 
          canDiff=fill(false)) where {V, T} = 
@@ -152,7 +142,7 @@ Return the value of the input variable of `pb`. Equivalent to `pb[]`.
 
 Return the value of the output variable of `pb`. Equivalent to `pb()`.
 """
-@inline outValOf(pb::ParamBox) = callGenFunc(pb.map, inValOf(pb))
+@inline outValOf(pb::ParamBox) = (pb.map∘inValOf)(pb)
 
 @inline outValOf(pb::ParamBox{<:Any, <:Any, FI}) = inValOf(pb)
 
@@ -335,7 +325,7 @@ compareParamBoxCore1(pb1::ParamBox, pb2::ParamBox) =
 (pb1.data[][begin] === pb2.data[][begin])
 
 compareParamBoxCore2(pb1::ParamBox{<:Any, V1}, pb2::ParamBox{<:Any, V2}) where {V1, V2} = 
-V1==V2 && compareParamBoxCore1(pb1, pb2) && (typeof(pb1.map) === typeof(pb2.map))
+V1==V2 && compareParamBoxCore1(pb1, pb2) && (pb1.map === pb2.map)
 
 compareParamBoxCore2(pb1::ParamBox{<:Any, V1, FI}, 
                      pb2::ParamBox{<:Any, V2, FI}) where {V1, V2} = 

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -325,7 +325,7 @@ compareParamBoxCore1(pb1::ParamBox, pb2::ParamBox) =
 (pb1.data[][begin] === pb2.data[][begin])
 
 compareParamBoxCore2(pb1::ParamBox{<:Any, V1}, pb2::ParamBox{<:Any, V2}) where {V1, V2} = 
-V1==V2 && compareParamBoxCore1(pb1, pb2) && (pb1.map === pb2.map)
+V1==V2 && compareParamBoxCore1(pb1, pb2) && hasIdentical(pb1.map, pb2.map)
 
 compareParamBoxCore2(pb1::ParamBox{<:Any, V1, FI}, 
                      pb2::ParamBox{<:Any, V2, FI}) where {V1, V2} = 
@@ -360,7 +360,7 @@ end
 function mulParamBox(c::Number, pb::ParamBox{T, V}, 
                      roundAtol::Real=nearestHalfOf(getAtolVal(T))) where {T, V}
     if isDiffParam(pb)
-        mapFunc = Pf(convert(T, roundToMultiOfStep(c, roundAtol)), pb.map)
+        mapFunc = Pf(pb.map, convert(T, roundToMultiOfStep(c, roundAtol)))
         ParamBox(Val(V), mapFunc, pb.data[], genIndex(nothing), fill(true))
     else
         ParamBox(Val(V), itself, 

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -784,10 +784,10 @@ arrayToTuple(coords)
 callGenFunc(f::F, x) where {F<:Function} = callGenFuncCore(worldAgeSafe(F), f, x)
 callGenFuncCore(::Val{true}, f, x) = f(x)
 function callGenFuncCore(::Val{false}, f::F, x) where {F}
+    @eval worldAgeSafe(::Type{$F}) = Val(true)
     try
         callGenFuncCore(Val(true), f, x)
     catch
-        @eval worldAgeSafe(::Type{$F}) = Val(true)
         Base.invokelatest(f, x)
     end
 end

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -170,9 +170,10 @@ function hasBoolRelation(boolOp::F, obj1::T1, obj2::T2;
     res
 end
 
-hasBoolRelation(boolOp::Function, obj1::Function, obj2::Function; 
+hasBoolRelation(boolOp::Function, obj1::F1, obj2::F2; 
                 ignoreFunction::Bool=false, ignoreContainer::Bool=false, 
-                decomposeNumberCollection::Bool=false) = 
+                decomposeNumberCollection::Bool=false) where 
+               {StructuredFunction<:F1<:Function, StructuredFunction<:F2<:Function} = 
 ifelse(ignoreFunction, true, boolOp(obj1, obj2))
 
 hasBoolRelation(boolOp::Function, obj1::Number, obj2::Number; 

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -605,15 +605,15 @@ function replaceSymbol(sym::Symbol, pair::Pair{String, String}; count::Int=typem
 end
 
 
-function renameFunc(fName::Symbol, f::F, ::Type{T}, N::Int=1) where {F<:Function, T}
-    @eval ($(fName))(a::Vararg{$T, $N}) = $f(a...)::$T
-end
+# function renameFunc(fName::Symbol, f::F, ::Type{T}, N::Int=1) where {F<:Function, T}
+#     @eval ($(fName))(a::Vararg{$T, $N}) = $f(a...)::$T
+# end
 
-function renameFunc(fName::Symbol, f::F, N::Int=1) where {F<:Function}
-    @eval ($(fName))(a::Vararg{Any, $N}) = $f(a...)
-end
+# function renameFunc(fName::Symbol, f::F, N::Int=1) where {F<:Function}
+#     @eval ($(fName))(a::Vararg{Any, $N}) = $f(a...)
+# end
 
-renameFunc(fName::String, args...) = renameFunc(Symbol(fName), args...)
+# renameFunc(fName::String, args...) = renameFunc(Symbol(fName), args...)
 
 
 function isOscillateConverged(seq::AbstractVector{T}, 
@@ -781,16 +781,20 @@ genTupleCoords(::Type{T}, coords::AbstractVector{NTuple{D, T}}) where {D, T} =
 arrayToTuple(coords)
 
 
-callGenFunc(f::F, x) where {F<:Function} = callGenFuncCore(worldAgeSafe(F), f, x)
-callGenFuncCore(::Val{true}, f, x) = f(x)
-function callGenFuncCore(::Val{false}, f::F, x) where {F}
-    @eval worldAgeSafe(::Type{$F}) = Val(true)
-    try
-        callGenFuncCore(Val(true), f, x)
-    catch
-        Base.invokelatest(f, x)
-    end
-end
+# callGenFunc(f::F, x) where {F<:Function} = callGenFuncCore(worldAgeSafe(F), f, x)
+# # callGenFuncCore(::Val{true}, f, x) = f(x)
+# @generated function callGenFuncCore(::Val{BL}, f::F, x) where {BL, F}
+#     if BL
+#         return :( f(x) )
+#     else
+#         # @eval worldAgeSafe(::Type{F}) = Val(true)
+#         expr = Expr(:(=), Expr(:call, :worldAgeSafe, Expr(:(::), Expr(:curly, :Type, :Int))), Expr(:call, :Val, :true))
+#         return quote
+#             $expr
+#             Base.invokelatest(f, x)
+#         end
+#     end
+# end
 
 worldAgeSafe(::Type{<:Function}) = Val(false)
 

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -142,30 +142,23 @@ function hasBoolRelation(boolOp::F, obj1::T1, obj2::T2;
                          ignoreContainer::Bool=false, 
                          decomposeNumberCollection::Bool=false) where {T1, T2, F<:Function}
     res = true
-    if T1 != T2 && !ignoreContainer && 
-          ( !ignoreFunction || typejoin(T1, T2) == Any || 
-            !(isa.([T1.parameters...], Type{<:FLevel}) |> any) || 
-            !(isa.([T2.parameters...], Type{<:FLevel}) |> any) )
-        return false
-    else
-        fs1 = fieldnames(T1)
-        fs2 = fieldnames(T2)
-        if fs1 == fs2
-            if length(fs1) == 0
-                res = boolOp(obj1, obj2)
-            else
-                for i in fs1
-                    isdefined(obj1, i) == (fieldDefined = isdefined(obj2, i)) && 
-                    (fieldDefined ? nothing : continue)
-                    res *= hasBoolRelation(boolOp, getproperty(obj1, i), 
-                                           getproperty(obj2, i); ignoreFunction, 
-                                           ignoreContainer, decomposeNumberCollection)
-                    !res && (return false)
-                end
-            end
+    fs1 = fieldnames(T1)
+    fs2 = fieldnames(T2)
+    if fs1 == fs2
+        if length(fs1) == 0
+            res = boolOp(obj1, obj2)
         else
-            return false
+            for i in fs1
+                isdefined(obj1, i) == (fieldDefined = isdefined(obj2, i)) && 
+                (fieldDefined ? nothing : continue)
+                res *= hasBoolRelation(boolOp, getproperty(obj1, i), 
+                                        getproperty(obj2, i); ignoreFunction, 
+                                        ignoreContainer, decomposeNumberCollection)
+                !res && (return false)
+            end
         end
+    else
+        return false
     end
     res
 end
@@ -244,14 +237,14 @@ false
 true
 ```
 """
-function hasBoolRelation(boolOp::F, obj1, obj2, obj3...; 
+function hasBoolRelation(boolOp::F, obj1, obj2, obj3, obj4...; 
                          ignoreFunction::Bool=false, 
                          ignoreContainer::Bool=false,
                          decomposeNumberCollection::Bool=false) where {F<:Function}
     res = hasBoolRelation(boolOp, obj1, obj2; ignoreFunction, ignoreContainer)
     tmp = obj2
     if res
-        for i in obj3[1:end]
+        for i in (obj3, obj4...)
             res *= hasBoolRelation(boolOp, tmp, i; ignoreFunction, ignoreContainer,
                                    decomposeNumberCollection)
             !res && break

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -582,7 +582,7 @@ A dummy function that returns its argument.
 """
 @inline itself(x) = x
 
-const itselfT = typeof(itself)
+const iT = typeof(itself)
 
 @inline themselves(xs::Vararg) = xs
 
@@ -597,17 +597,6 @@ Similar as `Base.replace` but for Symbols.
 function replaceSymbol(sym::Symbol, pair::Pair{String, String}; count::Int=typemax(Int))
     replace(sym |> string, pair; count) |> Symbol
 end
-
-
-# function renameFunc(fName::Symbol, f::F, ::Type{T}, N::Int=1) where {F<:Function, T}
-#     @eval ($(fName))(a::Vararg{$T, $N}) = $f(a...)::$T
-# end
-
-# function renameFunc(fName::Symbol, f::F, N::Int=1) where {F<:Function}
-#     @eval ($(fName))(a::Vararg{Any, $N}) = $f(a...)
-# end
-
-# renameFunc(fName::String, args...) = renameFunc(Symbol(fName), args...)
 
 
 function isOscillateConverged(seq::AbstractVector{T}, 

--- a/test/unit-tests/Basis-test.jl
+++ b/test/unit-tests/Basis-test.jl
@@ -61,10 +61,10 @@ c1_3 = genContraction(v1c)
 e2 = genExponent(e1)
 e3 = genExponent(c1)
 @test hasIdentical(e1, e2)
-@test !hasEqual(e1, e3)
+@test hasEqual(e1, e3)
 @test e1[] == e3[]
 @test e1() == e3()
-@test e1.map !== e3.map
+@test e1.map == e3.map
 v2 = rand()
 @test e1.map(v2) == e3.map(v2)
 e4 = genExponent(e1.data[])
@@ -80,7 +80,7 @@ c3 = genExponent(e1)
 @test !hasEqual(c1, c3)
 @test c1[] == c3[]
 @test c1() == c3()
-@test c1.map !== c3.map
+@test c1.map == c3.map
 @test c1.map(v2) == c3.map(v2)
 c4 = genExponent(c1.data[])
 @test c4.data[] === c1.data[]

--- a/test/unit-tests/Basis-test.jl
+++ b/test/unit-tests/Basis-test.jl
@@ -419,7 +419,7 @@ xpn2 = genExponent(1.2)
 con2 = genContraction(1.2, x->x^2)
 bf_pf = genBasisFunc([1.0, 2.0, 3.0], GaussFunc(xpn2, con2))
 bf_pf2 = (bf_pf*0.4)*5
-@test bf_pf2.gauss[1].con.map isa Quiqbox.Pf{Float64}
+@test bf_pf2.gauss[1].con.map isa Quiqbox.Pf{<:Function, Float64}
 @test hasEqual(bf_pf2, mul(bf_pf, 2.0))
 @test hasEqual(add(bf_add1, bf_add1), 
                add(bf_add1, deepcopy(bf_add1)), 

--- a/test/unit-tests/Basis-test.jl
+++ b/test/unit-tests/Basis-test.jl
@@ -1,6 +1,6 @@
 using Test
 using Quiqbox
-using Quiqbox: EmptyBasisFunc, BasisFuncMix, isaFullShellBasisFuncs, unpackBasis, 
+using Quiqbox: EmptyBasisFunc, BasisFuncMix, isaFullShellBasisFuncs, unpackBasis, iT, 
                ElementNames, sortBasisFuncs, ParamList, sumOf, mergeGaussFuncs, gaussProd, 
                getNormFactor, mergeBasisFuncs, getTypeParams
 using LinearAlgebra
@@ -146,7 +146,8 @@ bf2_P_norm3 = genBasisFunc(cen, gf2, "P")
 @test BasisFuncs(bf2_P_norm3) === bf2_P_norm3
 bfsp = BasisFuncs(genSpatialPoint(cen), gf2, (Quiqbox.LTuple(1,0,0),))
 @test hasEqual(collect(bfsp)[], BasisFunc(bfsp), bf2_P_norm3[1])
-@test getTypeParams(bf2_P_norm3) == (Float64, 3, 1, 1, Quiqbox.P3D{Float64, 0,0,0}, 3)
+@test getTypeParams(bf2_P_norm3) == 
+      (Float64, 3, 1, 1, Quiqbox.P3D{Float64, iT, iT, iT}, 3)
 
 bf3_1 = genBasisFunc(fill(0.0, 3), "STO-3G")[]
 bf3_2 = genBasisFunc(fill(0.0, 3), "STO-3G", "He")[]
@@ -244,7 +245,7 @@ bfm_bf2_P =  BasisFuncMix(bf2_P_norm3|>collect)
 @test hasEqual(bfm_bf2_P, BasisFuncMix([bfsp, bf2_P_norm3[2:end]...]))
 @test collect(gaussCoeffOf.(bfm_bf2_P.BasisFunc)) == fill(gaussCoeffOf(bf2_P_norm3), 3)
 @test getTypeParams(bfm1) == 
-      (Float64, 3, 1, BasisFunc{Float64, 3, 0, 1, P3D{Float64, 0, 0, 0}})
+      (Float64, 3, 1, BasisFunc{Float64, 3, 0, 1, P3D{Float64, iT, iT, iT}})
 
 errorThreshold2 = 5e-15
 bs1 = genBasisFunc.(gridCoordOf(GridBox(1,1.5)), Ref(GaussFunc(1.0, 0.5)))
@@ -419,7 +420,7 @@ xpn2 = genExponent(1.2)
 con2 = genContraction(1.2, x->x^2)
 bf_pf = genBasisFunc([1.0, 2.0, 3.0], GaussFunc(xpn2, con2))
 bf_pf2 = (bf_pf*0.4)*5
-@test bf_pf2.gauss[1].con.map isa Quiqbox.Pf{<:Function, Float64}
+@test bf_pf2.gauss[1].con.map isa Quiqbox.PF{<:Function, typeof(*), Float64}
 @test hasEqual(bf_pf2, mul(bf_pf, 2.0))
 @test hasEqual(add(bf_add1, bf_add1), 
                add(bf_add1, deepcopy(bf_add1)), 
@@ -814,8 +815,9 @@ pbs_gv0 = [cen_gv1[1], cen_gv2[1],
            cen_gv1[3], cen_gv2[3], cen_gv3[3], 
            e_gv1, e_gv2, e_gv3, 
            c_gv1, c_gv2, c_gv3]
-pbs_gv0_2 = sort(pbs_gv0, by=x->(Quiqbox.getFLevel(x.map), x.data[][end], x.index[]))
-pbs_gv3_2 = sort(pbs_gv3, by=x->(Quiqbox.getFLevel(x.map), x.data[][end], x.index[]))
+sortFunc = x->(string(Quiqbox.getFLevel(x.map)), x.data[][end], x.index[])
+pbs_gv0_2 = sort(pbs_gv0, by=sortFunc)
+pbs_gv3_2 = sort(pbs_gv3, by=sortFunc)
 @test pbs_gv3_2 == pbs_gv0_2
 @test hasEqual(pbs_gv3_2, pbs_gv0_2)
 @test hasIdentical(pbs_gv3_2, pbs_gv0_2)

--- a/test/unit-tests/Mapping-test.jl
+++ b/test/unit-tests/Mapping-test.jl
@@ -1,37 +1,93 @@
 using Test
 using Quiqbox
-using Quiqbox: itself, Pf, Sf, FLevel, getFLevel, Absolute, DressedItself
+using Quiqbox: FLevel, getFLevel, Absolute, DI, PF, combinePF, RC
 
 @testset "Mapping.jl" begin
 
-# struct FLevel & function getFLevel
-@test FLevel{getFLevel(:itself)} == FLevel(identity) == FLevel{0}
+# struct FLevel & function getFLevel & struct DI
+@test FLevel{getFLevel(itself)} == FLevel(identity) == FLevel{0}
 @test FLevel(abs) == FLevel{1}
-tf1 = Sf(abs, 2.2)
+tf1 = PF(abs, +, 2.2)
 @test FLevel{getFLevel(tf1)} == FLevel(tf1)
-pf1 = Pf(tf1, 1.5)
-@test FLevel(pf1) == FLevel{3}
-@test getFLevel(FLevel(tf1)) == getFLevel(typeof(tf1)) == getFLevel(tf1) == 2
+pf1 = PF(tf1, *, 1.5)
+@test FLevel(pf1) == FLevel{2}
+@test FLevel(tf1) == FLevel(typeof(tf1)) == FLevel(getFLevel(tf1)) == FLevel{2}
 @test getFLevel(Absolute(itself)) == 1
 @test getFLevel(Absolute(abs)) == 2
-DressedPf1 = DressedItself(pf1)
-@test getFLevel(DressedPf1) == 3
-@test DressedPf1 == DressedItself(DressedPf1)
+DressedPf1 = DI(pf1)
+@test getFLevel(DressedPf1) == 2
+@test DressedPf1 == DI(DressedPf1)
+a0 = fill(2.2)
+@test DressedPf1(a0) === a0
 
 
-# struct Pf
-pf1 = Pf(abs, -1.5)
+# struct PF and ChainedPF
+pf1 = PF(abs, *, -1.5)
 @test pf1(-2.0) == -3.0
-pf2 = Pf(abs, -1.5)
+pf2 = PF(abs, *, -1.5)
 @test pf2(-2) == -3.0
-@test Pf(pf2, -1.0)(-2.0) == 3.0
-@test Pf(Pf(itself, -1.5), -1.0)(-2) == -3.0
+pf3 = PF(pf2, *, -1.0)
+@test pf3 isa PF{typeof(abs), typeof(*)}
+@test pf3(-2.0) == 3.0
+@test PF(PF(itself, *, -1.5), *, -1.0)(-2) == -3.0
 
-
-# struct Sf
-sf1 = Sf(abs, 2)
+sf1 = PF(abs, +, 2)
 @test sf1(-1) == 3
-sf2 = Sf(sf1, 3)
-@test sf2(-1) == 6
+sf2 = PF(sf1, +, -4)
+@test sf2(-1) == -1
+@test sf2 isa PF{typeof(abs), typeof(+)}
+
+xf1 = PF(abs, ^, 2)
+xf2 = PF(abs, ^, 0.5)
+@test xf1(-1) == 1
+@test xf2(-4) == 2
+xf3 = PF(xf2, ^, -1)
+@test xf3 isa PF{typeof(abs), typeof(^)}
+
+cf1 = PF(pf1, +, 0.3)
+@test cf1 isa Quiqbox.ChainedPF{typeof(pf1.f), 2, Tuple{typeof(*), typeof(+)}}
+@test cf1(-0.33) == 0.33*(-1.5) + 0.3
+cf2 = PF(cf1, +, 0.2)
+@test cf2 isa Quiqbox.ChainedPF{typeof(pf1.f), 3}
+@test cf2(-0.33) == cf1(-0.33) + 0.2
+
+# function combinePF
+@test combinePF(+, pf1, pf2) == PF(abs, *, (pf1.c + pf2.c))
+pf4 = PF(abs, *, 1.5)
+@test combinePF(+, pf1, pf4)(rand()) == 0
+@test combinePF(+, sf1, sf2) == PF(abs, *, 2)
+sf3 = PF(sf2, +, 5)
+@test combinePF(+, sf1, sf3) == PF(PF(abs, *, 2), +, (sf1.c + sf3.c))
+@test combinePF(+, pf1, sf1) == combinePF(+, sf1, pf1) == 
+      PF(PF(abs, *, pf1.c+1), +, sf1.c)
+pf4 = PF(abs, *, -1)
+@test combinePF(+, pf4, sf1)(rand()) == combinePF(+, sf1, pf4)(rand()) == sf1.c
+pf5 = PF(abs, *, 0)
+@test combinePF(+, pf5, sf1) == PF(abs, +, sf1.c)
+cf3 = combinePF(+, pf1, sf1)
+@test cf3 == PF(PF(abs, *, (1+pf1.c)), +, sf1.c)
+cf3_t = combinePF(+, x->abs(x)*pf1.c, x->abs(x)+sf1.c)
+rn1 = rand()
+@test cf3(rn1) ≈ cf3_t(rn1)
+
+@test combinePF(*, pf1, pf2) == PF(PF(abs, ^, 2), *, pf1.c*pf2.c)
+r0 = combinePF(*, pf1, pf5)
+@test r0 isa RC{Float64}
+@test r0(rand()) == 0
+pf6 = PF(abs, *, 1/pf1.c)
+@test combinePF(*, pf1, pf6) == PF(abs, ^, 2)
+@test combinePF(*, xf1, xf2) == PF(abs, ^, xf1.c+xf2.c)
+xf3 = PF(abs, ^, -xf1.c)
+r1 = combinePF(*, xf1, xf3)
+@test r1 isa RC{Int}
+@test r1(rand()) == 1
+xf4 = PF(abs, ^, 1-xf1.c)
+@test combinePF(*, xf1, xf4) == xf1.f
+@test combinePF(*, xf1, pf1) == combinePF(*, pf1, xf1) == PF(PF(abs, ^, xf1.c+1), *, pf1.c)
+xf5 = PF(abs, ^, -1)
+@test combinePF(*, xf5, pf1)(rand()) == pf1.c
+xf6 = PF(abs, ^, 0)
+@test combinePF(*, xf6, pf1) == PF(abs, *, pf1.c)
+
 
 end

--- a/test/unit-tests/Mapping-test.jl
+++ b/test/unit-tests/Mapping-test.jl
@@ -7,9 +7,9 @@ using Quiqbox: itself, Pf, Sf, FLevel, getFLevel, Absolute, DressedItself
 # struct FLevel & function getFLevel
 @test FLevel{getFLevel(:itself)} == FLevel(identity) == FLevel{0}
 @test FLevel(abs) == FLevel{1}
-tf1 = Sf(2.2, abs)
+tf1 = Sf(abs, 2.2)
 @test FLevel{getFLevel(tf1)} == FLevel(tf1)
-pf1 = Pf(1.5, tf1)
+pf1 = Pf(tf1, 1.5)
 @test FLevel(pf1) == FLevel{3}
 @test getFLevel(FLevel(tf1)) == getFLevel(typeof(tf1)) == getFLevel(tf1) == 2
 @test getFLevel(Absolute(itself)) == 1
@@ -20,18 +20,18 @@ DressedPf1 = DressedItself(pf1)
 
 
 # struct Pf
-pf1 = Pf(-1.5, abs)
+pf1 = Pf(abs, -1.5)
 @test pf1(-2.0) == -3.0
-pf2 = Pf(-1.5, abs)
+pf2 = Pf(abs, -1.5)
 @test pf2(-2) == -3.0
-@test Pf(-1.0, pf2)(-2.0) == 3.0
-@test Pf(-1.0, Pf(-1.5, itself))(-2) == -3.0
+@test Pf(pf2, -1.0)(-2.0) == 3.0
+@test Pf(Pf(itself, -1.5), -1.0)(-2) == -3.0
 
 
 # struct Sf
-sf1 = Sf(2, abs)
+sf1 = Sf(abs, 2)
 @test sf1(-1) == 3
-sf2 = Sf(3, sf1)
+sf2 = Sf(sf1, 3)
 @test sf2(-1) == 6
 
 end

--- a/test/unit-tests/Optimization-test.jl
+++ b/test/unit-tests/Optimization-test.jl
@@ -30,21 +30,21 @@ arr0Ds = formatTunableParams!(pars0_1, bs0_1)
 @test mapreduce(hasEqual, *, pars0, pars0_0)
 testDetachedPars = function(ps0, ps1)
     bl = true
-    map(ps0, ps1) do p0, p1
+    map(enumerate(ps0), ps1) do (i, p0), p1
         if isDiffParam(p0) && isDiffParam(p1)
             bl1 = p0 === p1
-            bl1 || (@show bl1)
+            bl1 || (@show i bl1)
             bl *= bl1
         else
             bl2 = p0() == p1[] == p1()
-            bl2 || (@show bl2)
+            bl2 || (@show (i, bl2) p0() p1[] p1())
             bl3 = ( typeof(p1.map) == 
                     Quiqbox.DressedItself{Quiqbox.getFLevel(p0.map), typeof(p0.map)} )
-            bl3 || (@show bl3)
+            bl3 || (@show (i, bl3) typeof(p1.map) typeof(p0.map))
             bl4 = outSymOf(p0) == outSymOf(p1)
-            bl4 || (@show bl4)
+            bl4 || (@show (i, bl4))
             bl5 = isDiffParam(p0) == isDiffParam(p1)
-            bl5 || (@show bl5)
+            bl5 || (@show (i, bl5) isDiffParam(p0) isDiffParam(p1))
             bl *= bl2*bl3*bl4*bl5
         end
     end

--- a/test/unit-tests/Optimization-test.jl
+++ b/test/unit-tests/Optimization-test.jl
@@ -39,7 +39,7 @@ testDetachedPars = function(ps0, ps1)
             bl2 = p0() == p1[] == p1()
             bl2 || (@show (i, bl2) p0() p1[] p1())
             bl3 = ( typeof(p1.map) == 
-                    Quiqbox.DressedItself{Quiqbox.getFLevel(p0.map), typeof(p0.map)} )
+                    Quiqbox.DI{typeof(p0.map)} )
             bl3 || (@show (i, bl3) typeof(p1.map) typeof(p0.map))
             bl4 = outSymOf(p0) == outSymOf(p1)
             bl4 || (@show (i, bl4))
@@ -69,7 +69,7 @@ testαabsPars1 = function(ps0, ps1; sameDiff=true)
             bl1 || (@show bl1)
             bl2 = p0.map === p1.map.inner
             bl2 || (@show bl2)
-            bl3 = p1.map isa Quiqbox.Layered{typeof(abs)}
+            bl3 = p1.map isa Quiqbox.Labs
             bl3 || (@show bl3)
             bl4 = if sameDiff
                 p0.canDiff == p1.canDiff && p0.canDiff !== p1.canDiff
@@ -111,7 +111,7 @@ testαabsPars2 = function(ps0, ps1; onlyNegα=false)
             else
                 bl1 = p0.data[] === p1.data[]
                 bl2 = p0.map === p1.map.inner
-                bl3 = p1.map isa Quiqbox.Layered{typeof(abs)}
+                bl3 = p1.map isa Quiqbox.Labs
             end
             bl1 || (@show bl1)
             bl2 || (@show bl2)

--- a/test/unit-tests/Parameters-test.jl
+++ b/test/unit-tests/Parameters-test.jl
@@ -6,7 +6,7 @@ using Quiqbox: getTypeParams, FLevel, getFLevel, compareParamBox
 
 
 pb1 = ParamBox(1, :a)
-@test getTypeParams(pb1) == (Int, :a, Quiqbox.FI)
+@test getTypeParams(pb1) == (Int, :a, Quiqbox.IL)
 @test inSymOf(pb1) == :x_a
 @test outSymOf(pb1) == :a
 @test dataOf(pb1)[begin][] == pb1[] == inValOf(pb1)

--- a/test/unit-tests/Parameters-test.jl
+++ b/test/unit-tests/Parameters-test.jl
@@ -38,7 +38,6 @@ toggleDiff!(pb4)
 @test toggleDiff!(pb4)
 @test inSymOf(pb4) == :x
 @test outSymOf(pb4) == :c
-@test startswith(nameof(pb4.map) |> string, "f_c")
 
 pb5 = outValCopy(pb4)
 @test pb5() == pb5[] == pb4()

--- a/test/unit-tests/Parameters-test.jl
+++ b/test/unit-tests/Parameters-test.jl
@@ -1,12 +1,12 @@
 using Test
 using Quiqbox
-using Quiqbox: getTypeParams, FLevel, getFLevel, compareParamBox
+using Quiqbox: getTypeParams, getFLevel, compareParamBox
 
 @testset "Parameters.jl" begin
 
 
 pb1 = ParamBox(1, :a)
-@test getTypeParams(pb1) == (Int, :a, Quiqbox.IL)
+@test getTypeParams(pb1) == (Int, :a, Quiqbox.iT)
 @test inSymOf(pb1) == :x_a
 @test outSymOf(pb1) == :a
 @test dataOf(pb1)[begin][] == pb1[] == inValOf(pb1)
@@ -33,7 +33,7 @@ pb3 = ParamBox(-1, :b, abs)
 toggleDiff!(pb3)
 
 pb4 = ParamBox(1.2, :c, x->x^2, :x)
-@test getTypeParams(pb4) == (Float64, :c, FLevel(pb4.map))
+@test getTypeParams(pb4) == (Float64, :c, typeof(pb4.map))
 toggleDiff!(pb4)
 @test toggleDiff!(pb4)
 @test inSymOf(pb4) == :x

--- a/test/unit-tests/Tools-test.jl
+++ b/test/unit-tests/Tools-test.jl
@@ -174,9 +174,9 @@ end
 
 
 # function nameOf
-pf1 = Quiqbox.Pf(-1.5, abs)
+pf1 = Quiqbox.Pf(abs, -1.5)
 @test nameOf(abs) == :abs
-@test nameOf(pf1) == typeof(pf1) == Quiqbox.Pf{Float64, typeof(abs)}
+@test nameOf(pf1) == typeof(pf1) == Quiqbox.Pf{typeof(abs), Float64}
 
 
 # function tupleDiff

--- a/test/unit-tests/Tools-test.jl
+++ b/test/unit-tests/Tools-test.jl
@@ -2,10 +2,9 @@ using Test
 using Quiqbox
 using Quiqbox: getAtolVal, getAtolDigits, roundToMultiOfStep, nearestHalfOf, getNearestMid, 
                isApprox, tryIncluding, sizeOf, hasBoolRelation, flatten, joinTuple, 
-               markUnique, getUnique!, itself, themselves, replaceSymbol, renameFunc, 
-               groupedSort, mapPermute, getFunc, nameOf, tupleDiff, genIndex, fillObj, 
-               arrayToTuple, genTupleCoords, callGenFunc, uniCallFunc, mergeMultiObjs, 
-               isNaN, getBool, skipIndices
+               markUnique, getUnique!, itself, themselves, replaceSymbol, groupedSort, 
+               mapPermute, getFunc, nameOf, tupleDiff, genIndex, fillObj, arrayToTuple, 
+               genTupleCoords, uniCallFunc, mergeMultiObjs, isNaN, getBool, skipIndices
 using Suppressor: @capture_out
 
 @testset "Tools.jl" begin
@@ -110,26 +109,26 @@ x1 = rand(10)
 @test replaceSymbol(:sombol, "o"=>"y", count=1) == :symbol
 
 
-# function renameFunc
-f1 = renameFunc(:f_renameFunc_1, x->abs(x))
-@test f1(-0.1) === 0.1
-@test f1(-1) === 1
-@test nameof(f1) == :f_renameFunc_1
+# # function renameFunc
+# f1 = renameFunc(:f_renameFunc_1, x->abs(x))
+# @test f1(-0.1) === 0.1
+# @test f1(-1) === 1
+# @test nameof(f1) == :f_renameFunc_1
 
-f2 = renameFunc(:f_renameFunc_2, +, 2)
-arg1 = rand()
-arg2 = rand()
-@test f2(arg1, arg2) === (arg1 + arg2)
-@test try f2(1, arg1, arg2) catch; true end
+# f2 = renameFunc(:f_renameFunc_2, +, 2)
+# arg1 = rand()
+# arg2 = rand()
+# @test f2(arg1, arg2) === (arg1 + arg2)
+# @test try f2(1, arg1, arg2) catch; true end
 
-f3 = renameFunc(:f_renameFunc_3, abs, Float64)
-@test f3(-0.1) === 0.1
-@test try f3(-1) catch; true end
-@test typeof(f3) != typeof(abs)
+# f3 = renameFunc(:f_renameFunc_3, abs, Float64)
+# @test f3(-0.1) === 0.1
+# @test try f3(-1) catch; true end
+# @test typeof(f3) != typeof(abs)
 
-f4 = renameFunc("f_renameFunc_3", x->x+1, Float64)
-nameof(f4) == :f_renameFunc_3
-@test f3(-0.1) === 0.9
+# f4 = renameFunc("f_renameFunc_3", x->x+1, Float64)
+# nameof(f4) == :f_renameFunc_3
+# @test f3(-0.1) === 0.9
 
 
 # function groupedSort
@@ -214,8 +213,8 @@ c4 = c3 |> Tuple
 @test c4 == genTupleCoords(Float64, c4)
 
 
-# function callGenFunc
-@test callGenFunc(f1, -1) == 1
+# # function callGenFunc
+# @test callGenFunc(f1, -1) == 1
 
 
 # function uniCallFunc

--- a/test/unit-tests/Tools-test.jl
+++ b/test/unit-tests/Tools-test.jl
@@ -109,28 +109,6 @@ x1 = rand(10)
 @test replaceSymbol(:sombol, "o"=>"y", count=1) == :symbol
 
 
-# # function renameFunc
-# f1 = renameFunc(:f_renameFunc_1, x->abs(x))
-# @test f1(-0.1) === 0.1
-# @test f1(-1) === 1
-# @test nameof(f1) == :f_renameFunc_1
-
-# f2 = renameFunc(:f_renameFunc_2, +, 2)
-# arg1 = rand()
-# arg2 = rand()
-# @test f2(arg1, arg2) === (arg1 + arg2)
-# @test try f2(1, arg1, arg2) catch; true end
-
-# f3 = renameFunc(:f_renameFunc_3, abs, Float64)
-# @test f3(-0.1) === 0.1
-# @test try f3(-1) catch; true end
-# @test typeof(f3) != typeof(abs)
-
-# f4 = renameFunc("f_renameFunc_3", x->x+1, Float64)
-# nameof(f4) == :f_renameFunc_3
-# @test f3(-0.1) === 0.9
-
-
 # function groupedSort
 a = [rand(1:5, 2) for i=1:20]
 a2 = groupedSort(a)
@@ -174,9 +152,9 @@ end
 
 
 # function nameOf
-pf1 = Quiqbox.Pf(abs, -1.5)
+pf1 = Quiqbox.PF(abs, *, -1.5)
 @test nameOf(abs) == :abs
-@test nameOf(pf1) == typeof(pf1) == Quiqbox.Pf{typeof(abs), Float64}
+@test nameOf(pf1) == typeof(pf1) == Quiqbox.PF{typeof(abs), typeof(*), Float64}
 
 
 # function tupleDiff


### PR DESCRIPTION
- Removed `eval` and `invokelatest` to improve TTFX in edge cases;  gave up `renameFunc` in exchange for performance improvement.
- Replaced `FLevel` with actual function type in the position of the 3rd type parameter of `ParamBox` for better type stability
- Fixed a bug of `hasBoolRelation` that has been unveiled in Julia 1.8
- Changed `ParameterizedFunction` into concrete composite type `PF` and introduced `ChainedPF` to provide fusing of multiple `PF`s.