### PR TITLE
0.5-Performance Dev: Improve HF performance in edge cases

### DIFF
--- a/src/HartreeFock.jl
+++ b/src/HartreeFock.jl
@@ -20,7 +20,7 @@ const HFminItr = 10
 const HFinterEstoreSize = 15
 const HFinterValStoreSizes = (2,3,2, HFinterEstoreSize) # C(>1), D(>2), F(>1), E(>1)
 const defaultHFCStr = "HFconfig()"
-const defaultSCFconfigArgs = ( (:ADIIS, :DIIS), (1e-3, 1e-12) )
+const defaultSCFconfigArgs = ( (:ADIIS, :DIIS), (1e-3, 1e-10) )
 const defaultSecConvRatio = 100
 const defaultOscThreshold = 1e-6
 

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -19,6 +19,19 @@ function getAtolDigits(::Type{T}) where {T<:Real}
     end
 end
 
+function getAtolDigits(num::Real)
+    str = string(num)
+    idx1 = findlast('e', str)
+    if idx1 === nothing
+        idx2 = findlast('.', str)
+        length(str) - idx2
+    elseif str[idx1+1] == '-'
+        parse(Int, str[idx1+2:end])
+    else
+        0
+    end
+end
+
 
 """
 
@@ -960,3 +973,5 @@ mapMapReduce(tp::NTuple{N}, fs::NTuple{N, Function}, op::F=*) where {N, F} =
 mapreduce((x, y)->y(x), op, tp, fs)
 
 mapMapReduce(tp::NTuple{N}, f::F1, op::F2=*) where {N, F1, F2} = mapreduce(f, op, tp)
+
+rmsOf(arr::AbstractArray) = sqrt( sum(arr .^ 2) ./ length(arr) )

--- a/src/Tools.jl
+++ b/src/Tools.jl
@@ -899,10 +899,16 @@ end
 
 function shiftLastEle!(v, shiftVal)
     s = sum(v)
-    signedShift = asymSign(s)*shiftVal
-    s += signedShift
-    v[end] += signedShift
-    s, signedShift
+    shiftVal = abs(shiftVal)
+    offset = if s < shiftVal
+        signedShift = asymSign(s)*shiftVal
+        s += signedShift
+        v[end] += signedShift
+        signedShift
+    else
+        zero(s)
+    end
+    s, offset
 end
 
 

--- a/test/unit-tests/HartreeFock-test.jl
+++ b/test/unit-tests/HartreeFock-test.jl
@@ -295,4 +295,54 @@ end
 @test compr2Arrays2((Et1=Et1, rhfs=rhfs), 95, errorThreshold1, 0.6)
 @test compr2Arrays2((Et2=Et2, uhfs=uhfs), 16, errorThreshold1, 5e-5, <)
 
+
+# Extreme Case tests
+AtoBr = 1.8897259886
+
+## H2O2
+t1 = 1e-10
+
+nuc_H2O2 = ["O", "O", "H", "H"]
+coords_H2O2 = [[0., 0.731, 0.], [0., -0.731, 0.], 
+               [0.936, 0.916, 0.], [-0.936, -0.916, 0.]] .* AtoBr
+Ehf_H2O2 = -187.42063898359095
+
+HFc0 = HFconfig()
+
+HFc1 = HFconfig(C0=:SAD, SCF=SCFconfig(threshold=t1))
+HFc2 = HFconfig(C0=:Hcore, SCF=SCFconfig(threshold=t1))
+HFc3 = HFconfig(C0=:GWH, SCF=SCFconfig(threshold=t1))
+
+HFc4 = HFconfig(C0=:SAD, SCF=SCFconfig((:DIIS,), (t1,)))
+HFc5 = HFconfig(C0=:SAD, SCF=SCFconfig((:EDIIS,), (t1,)))
+HFc6 = HFconfig(C0=:SAD, SCF=SCFconfig((:ADIIS,), (t1,)))
+
+HFc7 = HFconfig(C0=:Hcore, SCF=SCFconfig((:DIIS,), (t1,)))
+HFc8 = HFconfig(C0=:Hcore, SCF=SCFconfig((:EDIIS,), (t1,)))
+HFc9 = HFconfig(C0=:Hcore, SCF=SCFconfig((:ADIIS,), (t1,)))
+
+HFc10 = HFconfig(C0=:GWH, SCF=SCFconfig((:DIIS,), (t1,)))
+HFc11 = HFconfig(C0=:GWH, SCF=SCFconfig((:EDIIS,), (t1,)))
+HFc12 = HFconfig(C0=:GWH, SCF=SCFconfig((:ADIIS,), (t1,)))
+
+HFc13 = HFconfig(C0=:SAD, SCF=SCFconfig(threshold=1e-9, secondaryConvRatio=1))
+HFc14 = HFconfig(C0=:Hcore, SCF=SCFconfig(threshold=1e-9, secondaryConvRatio=1))
+HFc15 = HFconfig(C0=:GWH, SCF=SCFconfig(threshold=1e-9, secondaryConvRatio=1))
+
+HFcs = (HFc0,  HFc1,  HFc2,  HFc3,  HFc4,  HFc5,  HFc6,  HFc7,  HFc8,  HFc9, 
+        HFc10, HFc11, HFc12, HFc13, HFc14, HFc15)
+
+for HFc in (HFcs)
+    bs = genBasisFunc.(coords_H2O2, "6-31G", nuc_H2O2) |> flatten
+    local res3
+    info3 = @capture_out begin
+        @show HFc
+        res3 = runHF(bs, nuc_H2O2, coords_H2O2, HFc, printInfo=true)
+    end
+    bl = isapprox(res3.Ehf, Ehf_H2O2, atol=t1)
+    bl || println(info3)
+    @test bl
+    @test res3.isConverged
+end
+
 end

--- a/test/unit-tests/Overload-test.jl
+++ b/test/unit-tests/Overload-test.jl
@@ -94,7 +94,8 @@ l3 = length(fVarStrP1)
 info3 = (@capture_out replShow(SCFconfig((:DD, :ADIIS, :DIIS), 
                                          (1e-4, 1e-12, 1e-13), Dict(2=>[:solver=>:LCM]))))
 @test info3 == "SCFconfig{Float64, 3, Tuple{Val{:DD}, Val{:ADIIS}, Val{:DIIS}}}(method, "*
-               "interval=(0.0001, 1.0e-12, 1.0e-13), methodConfig, oscillateThreshold)"
+               "interval=(0.0001, 1.0e-12, 1.0e-13), methodConfig, secondaryConvRatio, "*
+               "oscillateThreshold)"
 
 H2 = MatterByHF(fVar1)
 info4 = (@capture_out replShow(H2))


### PR DESCRIPTION
- Added `resetThreshold` keyword for xDIIS to control when to reset DIIS subspace.
- Added computation of `[FDS - SDF]` (regardless of the applied iterative HF solver) for convergence criteria.
- Added `secondaryConvRatio` for `SCFconfig` to control the convergence threshold of `ΔDrms` and `∇Erms`.