### PR TITLE
0.6-Debug Dev

### DIFF
--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -1185,6 +1185,8 @@ getOutputType(::Type{<:SpanSetCaller{T}}) where {T} = T
     return :( (unit=($upType)[], grid=($gpType)[]) )
 end
 
+initializeSpanParamSet(::Nothing) = initializeFixedSpanSet(nothing)
+
 initializeSpanParamSet(unit::UnitParam) = (unit=genMemory(unit), grid=genBottomMemory())
 
 initializeSpanParamSet(grid::GridParam) = (unit=genBottomMemory(), grid=genMemory(grid))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ using Test
         include("unit-tests/Mapping-test.jl")
         include("unit-tests/Operators-test.jl")
         include("unit-tests/Parameters-test.jl")
+        include("unit-tests/Graphs-test.jl")
     end
     println("$(unit3) test finished in $t3 seconds.\n")
 

--- a/test/unit-tests/Graphs-test.jl
+++ b/test/unit-tests/Graphs-test.jl
@@ -1,0 +1,19 @@
+using Test
+using Quiqbox
+
+@testset "Graphs.jl" begin
+
+v1 = genTensorVar([1, 2], :a, true)
+f = ParamGraphCaller(v1)
+
+@test f.source == Quiqbox.initializeFixedSpanSet()
+@test typeof(f.source) == typeof(Quiqbox.initializeFixedSpanSet())
+
+@test try f((unit=[1], grid=[[2]])) catch; true end
+@test try f((unit=[1], grid=nothing)) catch; true end
+@test try f((unit=nothing, grid=[[2]])) catch; true end
+
+@test f(initializeSpanParamSet(nothing)) == v1()
+@test f(( unit=nothing, grid=Quiqbox.genBottomMemory() )) == v1()
+
+end

--- a/test/unit-tests/Parameters-test.jl
+++ b/test/unit-tests/Parameters-test.jl
@@ -124,9 +124,8 @@ a2in, _, a2out, a2self = dissectParam(a2)
 @test a2.offset == a1Val == a1.offset + v1Val
 
 v1ValNew = 0.9
-setScreenLevel!(v1, 2)
-@test try setVal!(v1, v1ValNew) catch; true end
-setScreenLevel!(v1, 1)
+v1_2 = genTensorVar(v1(), symOf(v1), true)
+@test try setVal!(v1_2, v1ValNew) catch; true end
 setVal!(v1, v1ValNew)
 @test obtain(v1) == v1ValNew
 @atomic a1.offset = 0.0


### PR DESCRIPTION
- Fixed the input constraint of storage-like functions generated from screened `ParamBox`.
- Removed mutability of `.screen` in `TensorVar`.