### PR TITLE
Trying out more optimal simplification of unpacking `FieldAmplitude` for integral computations

### DIFF
--- a/src/Dispatch.jl
+++ b/src/Dispatch.jl
@@ -75,6 +75,10 @@ struct True  <: ValueType end
 struct False <: ValueType end
 const Boolean = Union{True, False}
 
+negate(::True) = False()
+negate(::False) = True()
+
+
 getTypeValue(::Type{True }) = true
 getTypeValue(::Type{False}) = false
 

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -430,11 +430,16 @@ const ParamMapper{F<:FunctionChainUnion{ParamMapperCore}} = ChainMapper{F}
 const NamedParamMapper{S, F<:NamedTuple{ S, <:NonEmptyTuple{ParamMapperCore} }} = 
       ParamMapper{F}
 
-function genParamMapper(params::DirectParamSource; 
+function isActiveSpanParam(param::ParamBox)
+    (param isa SpanParam) && (screenLevelOf(param) < 2)
+end
+
+function genParamMapper(params::DirectParamSource, 
+                        activeTranspilation::Boolean=True(); 
                         paramSet!Self::OptSpanParamSet=initializeSpanParamSet())
     checkEmptiness(params, :params)
     mapper = map(params) do param
-        if screenLevelOf(param) == 1
+        if !getTypeValue(activeTranspilation) && isActiveSpanParam(param)
             paramIndexer = locateParam!(paramSet!Self, param)
             TypedReturn(GetEntry(paramIndexer), getOutputType(param))
         else

--- a/src/Spatial.jl
+++ b/src/Spatial.jl
@@ -92,20 +92,22 @@ function unpackFieldFunc(f::F, ::Boolean=False()) where
     TypedCarteFunc(RPartial(f.core.f.f, f.data), C, Count(D)), initializeSpanParamSet()
 end
 
-#> `trySevering` is the unique argument for unpacking `FieldAmplitude`, which when set to 
-#> `true`, will let `unpackFunc!` and `unpackFunc` sever the explicit parameters.
-function unpackFunc!(f::F, paramSet::OptSpanParamSet, trySevering::Boolean=False(); 
+#>> `directUnpack` is a unique argument for unpacking `FieldAmplitude`. When it is set to 
+#>> `True()::Boolean`, `unpackFunc!` and `unpackFunc` will extract input `FieldAmplitude`'s
+#>> direct parameters which might still be correlated with each other due to their internal 
+#>> computation graphs.
+function unpackFunc!(f::F, paramSet::OptSpanParamSet, directUnpack::Boolean=False(); 
                      paramSetId::Identifier=Identifier(paramSet)) where 
                     {T, C<:RealOrComplex{T}, D, F<:FieldAmplitude{C, D}}
-    fCore, localParamSet = unpackFieldFunc(f, trySevering)
+    fCore, localParamSet = unpackFieldFunc(f, directUnpack)
     idxFilter = locateParam!(paramSet, localParamSet)
     scope = TaggedSpanSetFilter(idxFilter, paramSetId)
     FieldParamFunc(fCore, scope)
 end
 
-function unpackFunc(f::F, trySevering::Boolean=False()) where 
+function unpackFunc(f::F, directUnpack::Boolean=False()) where 
                    {T, C<:RealOrComplex{T}, D, F<:FieldAmplitude{C, D}}
-    fCore, paramSet = unpackFieldFunc(f, trySevering)
+    fCore, paramSet = unpackFieldFunc(f, directUnpack)
     idxFilter = SpanSetFilter(map(length, paramSet)...)
     scope = TaggedSpanSetFilter(idxFilter, paramSet)
     FieldParamFunc(fCore, scope), paramSet
@@ -238,14 +240,9 @@ function evalFieldAmplitudeCore(f::ModularField, input, cache!Self::ParamDataCac
     f.core(formatInput(f, input), paramVals)
 end
 
-function unpackFieldFunc(f::F, trySevering::Boolean=False()) where 
+function unpackFieldFunc(f::F, directUnpack::Boolean=False()) where 
                         {C<:RealOrComplex, D, F<:ModularField{C, D}}
-    params = if getTypeValue(trySevering)
-        map(p->sever(p, isFrozenVariable(p)), f.param)
-    else
-        f.param
-    end
-    paramMapper, paramSet = genParamMapper(params)
+    paramMapper, paramSet = genParamMapper(f.param, negate(directUnpack))
     TypedCarteFunc(ContextParamFunc(f.core.f.f, paramMapper), C, Count(D)), paramSet
 end
 
@@ -299,7 +296,7 @@ function evalFieldAmplitude(f::ProductField{C}, input;
     end
 end
 
-function unpackFieldFunc(f::F, trySevering::Boolean=False()) where 
+function unpackFieldFunc(f::F, directUnpack::Boolean=False()) where 
                         {C<:RealOrComplex, D, F<:ProductField{C, D}}
     paramSet = initializeSpanParamSet()
 
@@ -308,7 +305,7 @@ function unpackFieldFunc(f::F, trySevering::Boolean=False()) where
         basisDim = getDimension(basis)
         getSubIdx = ViewOneToRange(idx, Count{basisDim}())
         idx += basisDim
-        basisCore = unpackFunc!(basis, paramSet, trySevering, paramSetId=Identifier())
+        basisCore = unpackFunc!(basis, paramSet, directUnpack, paramSetId=Identifier())
         ParamPipeline((InputConverter(getSubIdx), basisCore))
     end
 
@@ -351,12 +348,12 @@ function evalFieldAmplitude(f::CoupledField, input;
     end |> Base.Splat(f.coupler)
 end
 
-function unpackFieldFunc(f::F, trySevering::Boolean=False()) where 
+function unpackFieldFunc(f::F, directUnpack::Boolean=False()) where 
                         {D, C<:RealOrComplex, F<:CoupledField{C, D}}
     fL, fR = f.pair
     paramSet = initializeSpanParamSet()
-    fCoreL = unpackFunc!(fL, paramSet, trySevering, paramSetId=Identifier())
-    fCoreR = unpackFunc!(fR, paramSet, trySevering, paramSetId=Identifier())
+    fCoreL = unpackFunc!(fL, paramSet, directUnpack, paramSetId=Identifier())
+    fCoreR = unpackFunc!(fR, paramSet, directUnpack, paramSetId=Identifier())
     TypedCarteFunc(ParamCombiner(f.coupler, (fCoreL, fCoreR)), C, Count(D)), paramSet
 end
 
@@ -419,15 +416,10 @@ function evalFieldAmplitudeCore(f::ShiftedField{T, D}, input,
     f.core(shiftedCoord)
 end
 
-function unpackFieldFunc(f::F, trySevering::Boolean=False()) where 
+function unpackFieldFunc(f::F, directUnpack::Boolean=False()) where 
                         {T, C<:RealOrComplex{T}, D, F<:ShiftedField{C, D}}
-    fInner, paramSet = unpackFieldFunc(f.core, trySevering)
-    cenParams = if getTypeValue(trySevering)
-        map(p->sever(p, isFrozenVariable(p)), f.center)
-    else
-        f.center
-    end
-    mapper, _ = genParamMapper(cenParams, paramSet!Self=paramSet)
+    fInner, paramSet = unpackFieldFunc(f.core, directUnpack)
+    mapper, _ = genParamMapper(f.center, negate(directUnpack), paramSet!Self=paramSet)
     shiftCore = StableTupleSub(T, Count(D))
     shifter = ContextParamFunc(shiftCore, CartesianFormatter(T, Count(D)), mapper)
     TypedCarteFunc(ParamPipeline((shifter, fInner.f.f)), T, Count(D)), paramSet


### PR DESCRIPTION
Instead of first converting applicable `paramBox` into simplified versions through `sever`, directly bypass the generation of `ParamGraphCaller` if they are `SpanParam`.