### PR TITLE
0.6-Optimization Dev

### DIFF
--- a/src/Dispatch.jl
+++ b/src/Dispatch.jl
@@ -76,8 +76,10 @@ Base.broadcastable(o::ValueType) = Ref(o)
 struct True  <: ValueType end
 struct False <: ValueType end
 const Boolean = Union{True, False}
+const AbstractBool = Union{Boolean, Bool}
 
 toBoolean(bl::Bool) = ifelse(bl, True(), False())
+toBoolean(bl::Boolean) = itself(bl)
 
 negate(::True) = False()
 negate(::False) = True()

--- a/src/Dispatch.jl
+++ b/src/Dispatch.jl
@@ -77,6 +77,8 @@ struct True  <: ValueType end
 struct False <: ValueType end
 const Boolean = Union{True, False}
 
+toBoolean(bl::Bool) = ifelse(bl, True(), False())
+
 negate(::True) = False()
 negate(::False) = True()
 

--- a/src/Dispatch.jl
+++ b/src/Dispatch.jl
@@ -42,9 +42,9 @@ formatInput(f::Function, x) = formatInput(SelectTrait{InputStyle}()(f), x)
 
 abstract type IntegralStyle <: AnyInterface end
 
-struct MultiBodyIntegral{N, D} <: IntegralStyle end
-const OneBodyIntegral{D} = MultiBodyIntegral{1, D}
-const TwoBodyIntegral{D} = MultiBodyIntegral{2, D}
+struct MultiBodyIntegral{D, C, N} <: IntegralStyle end
+const OneBodyIntegral{D, C} = MultiBodyIntegral{D, C, 1}
+const TwoBodyIntegral{D, C} = MultiBodyIntegral{D, C, 2}
 
 
 strictTypeJoin(TL::Type, TR::Type) = typejoin(TL, TR)

--- a/src/Integration/Engines/Numerical.jl
+++ b/src/Integration/Engines/Numerical.jl
@@ -49,8 +49,8 @@ struct DoubleFieldProd{T<:Real, D, O<:DualTermOperator,
     coupler::O
 end
 
-function DoubleFieldProd(pairL::N12Tuple{PrimOrbData{T, D}}, 
-                         pairR::N12Tuple{PrimOrbData{T, D}}, 
+function DoubleFieldProd(pairL::NTuple{2, FieldAmplitude{<:RealOrComplex{T}, D}}, 
+                         pairR::NTuple{2, FieldAmplitude{<:RealOrComplex{T}, D}}, 
                          coupler::DualTermOperator) where {T, D}
     sfProdL = SesquiFieldProd(pairL)
     sfProdR = SesquiFieldProd(pairR)
@@ -83,19 +83,20 @@ end
 
 
 function genIntegrant(op::Multiplier, 
-                      (pair,)::Tuple{ NTuple{ 2, PrimOrbData{T, D} }}) where {T<:Real, D}
-    SesquiFieldProd(getfield.(pair, :core), op)
+                      (pair,)::Tuple{NTuple{ 2, StashedShiftedField{T, D} }}
+                      ) where {T<:Real, D}
+    SesquiFieldProd(pair, op)
 end
 
 function genIntegrant(op::DualTermOperator, 
-                      (pL, pR)::NTuple{2, NTuple{ 2, PrimOrbData{T, D} }}
+                      (pL, pR)::NTuple{2, NTuple{ 2, StashedShiftedField{T, D} }}
                       ) where {T<:Real, D}
-    DoubleFieldProd(getfield.(pL, :core), getfield.(pR, :core), op)
+    DoubleFieldProd(pL, pR, op)
 end
 
 
 function genIntegralSectors(op::DirectOperator, 
-                            layout::N12Tuple{NTuple{ 2, PrimOrbData{T, D} }}
+                            layout::N12N2Tuple{StashedShiftedField{T, D}}
                             ) where {T<:Real, D}
     *, tuple(genIntegrant(op, layout))
 end
@@ -108,7 +109,7 @@ end
 
 function estimateOrbIntegral(config::MissingOr{EstimatorConfig{T}}, 
                              op::TypedOperator{C}, 
-                             layout::N12Tuple{NTuple{ 2, PrimOrbData{T, D} }}
+                             layout::N12N2Tuple{StashedShiftedField{T, D}}
                              ) where {T<:Real, C<:RealOrComplex{T}, D}
     combiner, sectors = genIntegralSectors(op.core, layout)
     noGlobalConfig = ismissing(config)

--- a/src/Integration/Framework.jl
+++ b/src/Integration/Framework.jl
@@ -129,6 +129,12 @@ end
 function evaluateIntegral!(config::OrbitalCoreIntegralConfig{T, D, C, N, F}, 
                            pairwiseData::NTuple{N, NTuple{ 2, PrimOrbData{T, D} }}) where 
                           {T, C<:RealOrComplex{T}, D, N, F<:DirectOperator}
+    evaluateIntegralCore(config, pairwiseData)
+end
+
+function evaluateIntegralCore(config::OrbitalCoreIntegralConfig{T, D, C, N, F}, 
+                              pairwiseData::NTuple{N, NTuple{ 2, PrimOrbData{T, D} }}) where 
+                             {T, C<:RealOrComplex{T}, D, N, F<:DirectOperator}
     formattedOp = TypedOperator(config.operator, C)
     estimateOrbIntegral(config.estimator, formattedOp, pairwiseData)::C
 end

--- a/src/Integration/Interface.jl
+++ b/src/Integration/Interface.jl
@@ -1,13 +1,14 @@
 export overlap, overlaps, multipoleMoment, multipoleMoments, eKinetic, eKinetics
 
 function overlap(orb1::OrbitalBasis{C1, D}, orb2::OrbitalBasis{C2, D}; 
-                 cache!Self::ParamDataCache=initializeParamDataCache(), 
+                 cache!Self::MissingOr{ParamDataCache}=missing, 
                  estimatorConfig::OptEstimatorConfig{T}=missing, 
                  lazyCompute::AbstractBool=True()) where 
                 {T<:Real, C1<:RealOrComplex{T}, C2<:RealOrComplex{T}, D}
     if orb1 === orb2 && isRenormalized(orb1)
         one(T)
     else
+        ismissing(cache!Self) && (cache!Self = initializeParamDataCache())
         lazyCompute = toBoolean(lazyCompute)
         computeLayoutIntegral(genOverlapSampler(), (orb1, orb2); 
                               cache!Self, estimatorConfig, lazyCompute)

--- a/src/Integration/Interface.jl
+++ b/src/Integration/Interface.jl
@@ -3,11 +3,12 @@ export overlap, overlaps, multipoleMoment, multipoleMoments, eKinetic, eKinetics
 function overlap(orb1::OrbitalBasis{C1, D}, orb2::OrbitalBasis{C2, D}; 
                  cache!Self::ParamDataCache=initializeParamDataCache(), 
                  estimatorConfig::OptEstimatorConfig{T}=missing, 
-                 lazyCompute::Boolean=True()) where 
+                 lazyCompute::AbstractBool=True()) where 
                 {T<:Real, C1<:RealOrComplex{T}, C2<:RealOrComplex{T}, D}
     if orb1 === orb2 && isRenormalized(orb1)
         one(T)
     else
+        lazyCompute = toBoolean(lazyCompute)
         computeLayoutIntegral(genOverlapSampler(), (orb1, orb2); 
                               cache!Self, estimatorConfig, lazyCompute)
     end
@@ -16,7 +17,7 @@ end
 function overlaps(basisSet::OrbBasisVector{T, D}; 
                   cache!Self::ParamDataCache=initializeParamDataCache(), 
                   estimatorConfig::OptEstimatorConfig{T}=missing, 
-                  lazyCompute::Boolean=True()) where {T<:Real, D}
+                  lazyCompute::AbstractBool=True()) where {T<:Real, D}
     computeVectorIntegral(OneBodyIntegral{D, T}(), genOverlapSampler(), basisSet; 
                           cache!Self, estimatorConfig, lazyCompute)
 end
@@ -26,8 +27,9 @@ function multipoleMoment(center::NTuple{D, Real}, degrees::NTuple{D, Int},
                          orb1::OrbitalBasis{C1, D}, orb2::OrbitalBasis{C2, D}; 
                          cache!Self::ParamDataCache=initializeParamDataCache(), 
                          estimatorConfig::OptEstimatorConfig{T}=missing, 
-                         lazyCompute::Boolean=True()) where 
+                         lazyCompute::AbstractBool=True()) where 
                         {T<:Real, C1<:RealOrComplex{T}, C2<:RealOrComplex{T}, D}
+    lazyCompute = toBoolean(lazyCompute)
     mmOp = (genMultipoleMomentSampler∘FloatingMonomial)(T.(center), degrees)
     computeLayoutIntegral(mmOp, (orb1, orb2); cache!Self, estimatorConfig, lazyCompute)
 end
@@ -36,7 +38,8 @@ function multipoleMoments(center::NTuple{D, Real}, degrees::NTuple{D, Int},
                           basisSet::OrbBasisVector{T, D}; 
                           cache!Self::ParamDataCache=initializeParamDataCache(), 
                           estimatorConfig::OptEstimatorConfig{T}=missing, 
-                          lazyCompute::Boolean=True()) where {T<:Real, D}
+                          lazyCompute::AbstractBool=True()) where {T<:Real, D}
+    lazyCompute = toBoolean(lazyCompute)
     mmOp = (genMultipoleMomentSampler∘FloatingMonomial)(T.(center), degrees)
     computeVectorIntegral(OneBodyIntegral{D, T}(), mmOp, basisSet; 
                           cache!Self, estimatorConfig, lazyCompute)
@@ -47,8 +50,9 @@ function eKinetic(orb1::OrbitalBasis{C1, D}, orb2::OrbitalBasis{C2, D},
                   config::KineticEnergySampler{T, D}=genKineticEnergySampler(T, Count(D)); 
                   cache!Self::ParamDataCache=initializeParamDataCache(), 
                   estimatorConfig::OptEstimatorConfig{T}=missing, 
-                  lazyCompute::Boolean=True()) where 
+                  lazyCompute::AbstractBool=True()) where 
                  {T<:Real, C1<:RealOrComplex{T}, C2<:RealOrComplex{T}, D}
+    lazyCompute = toBoolean(lazyCompute)
     computeLayoutIntegral(config.core, (orb1, orb2); 
                           cache!Self, estimatorConfig, lazyCompute)
 end
@@ -57,7 +61,8 @@ function eKinetics(basisSet::OrbBasisVector{T, D},
                    config::KineticEnergySampler{T, D}=genKineticEnergySampler(T, Count(D)); 
                    cache!Self::ParamDataCache=initializeParamDataCache(), 
                    estimatorConfig::OptEstimatorConfig{T}=missing, 
-                   lazyCompute::Boolean=True()) where {T<:Real, D}
+                   lazyCompute::AbstractBool=True()) where {T<:Real, D}
+    lazyCompute = toBoolean(lazyCompute)
     computeVectorIntegral(OneBodyIntegral{D, T}(), config.core, basisSet; 
                           cache!Self, estimatorConfig, lazyCompute)
 end

--- a/src/Integration/Interface.jl
+++ b/src/Integration/Interface.jl
@@ -1,53 +1,63 @@
 export overlap, overlaps, multipoleMoment, multipoleMoments, eKinetic, eKinetics
 
 function overlap(orb1::OrbitalBasis{C1, D}, orb2::OrbitalBasis{C2, D}; 
-                 cache!Self::MissingOr{ParamDataCache}=missing, 
-                 lazyCompute::Bool=false) where {T<:Real, C1<:RealOrComplex{T}, 
-                                                 C2<:RealOrComplex{T}, D}
+                 cache!Self::ParamDataCache=initializeParamDataCache(), 
+                 estimatorConfig::OptEstimatorConfig{T}=missing, 
+                 lazyCompute::Boolean=True()) where 
+                {T<:Real, C1<:RealOrComplex{T}, C2<:RealOrComplex{T}, D}
     if orb1 === orb2 && isRenormalized(orb1)
         one(T)
     else
-        ismissing(cache!Self) && (cache!Self = initializeParamDataCache())
-        computeIntegral(OneBodyIntegral{D}(), genOverlapSampler(), (orb1, orb2); 
-                        cache!Self, lazyCompute)
+        computeLayoutIntegral(genOverlapSampler(), (orb1, orb2); 
+                              cache!Self, estimatorConfig, lazyCompute)
     end
 end
 
-function overlaps(basisSet::OrbBasisVec{<:Real, D}; 
-                  cache!Self::ParamDataCache=initializeParamDataCache()) where {D}
-    computeIntTensor(OneBodyIntegral{D}(), genOverlapSampler(), basisSet; cache!Self)
+function overlaps(basisSet::OrbBasisVector{T, D}; 
+                  cache!Self::ParamDataCache=initializeParamDataCache(), 
+                  estimatorConfig::OptEstimatorConfig{T}=missing, 
+                  lazyCompute::Boolean=True()) where {T<:Real, D}
+    computeVectorIntegral(OneBodyIntegral{D, T}(), genOverlapSampler(), basisSet; 
+                          cache!Self, estimatorConfig, lazyCompute)
 end
 
 
 function multipoleMoment(center::NTuple{D, Real}, degrees::NTuple{D, Int}, 
                          orb1::OrbitalBasis{C1, D}, orb2::OrbitalBasis{C2, D}; 
                          cache!Self::ParamDataCache=initializeParamDataCache(), 
-                         lazyCompute::Bool=false) where {T<:Real, C1<:RealOrComplex{T}, 
-                                                         C2<:RealOrComplex{T}, D}
+                         estimatorConfig::OptEstimatorConfig{T}=missing, 
+                         lazyCompute::Boolean=True()) where 
+                        {T<:Real, C1<:RealOrComplex{T}, C2<:RealOrComplex{T}, D}
     mmOp = (genMultipoleMomentSampler∘FloatingMonomial)(T.(center), degrees)
-    computeIntegral(OneBodyIntegral{D}(), mmOp, (orb1, orb2); cache!Self, lazyCompute)
+    computeLayoutIntegral(mmOp, (orb1, orb2); cache!Self, estimatorConfig, lazyCompute)
 end
 
 function multipoleMoments(center::NTuple{D, Real}, degrees::NTuple{D, Int}, 
-                          basisSet::OrbBasisVec{<:Real, D}; 
-                          cache!Self::ParamDataCache=initializeParamDataCache()
-                          ) where {D}
+                          basisSet::OrbBasisVector{T, D}; 
+                          cache!Self::ParamDataCache=initializeParamDataCache(), 
+                          estimatorConfig::OptEstimatorConfig{T}=missing, 
+                          lazyCompute::Boolean=True()) where {T<:Real, D}
     mmOp = (genMultipoleMomentSampler∘FloatingMonomial)(T.(center), degrees)
-    computeIntTensor(OneBodyIntegral{D}(), mmOp, basisSet; cache!Self)
+    computeVectorIntegral(OneBodyIntegral{D, T}(), mmOp, basisSet; 
+                          cache!Self, estimatorConfig, lazyCompute)
 end
 
 
 function eKinetic(orb1::OrbitalBasis{C1, D}, orb2::OrbitalBasis{C2, D}, 
-                  operator::KineticEnergySampler{T, D}=genKineticEnergySampler(T, Count(D)); 
-                  cache!Self::MissingOr{ParamDataCache}=missing, 
-                  lazyCompute::Bool=false) where 
+                  config::KineticEnergySampler{T, D}=genKineticEnergySampler(T, Count(D)); 
+                  cache!Self::ParamDataCache=initializeParamDataCache(), 
+                  estimatorConfig::OptEstimatorConfig{T}=missing, 
+                  lazyCompute::Boolean=True()) where 
                  {T<:Real, C1<:RealOrComplex{T}, C2<:RealOrComplex{T}, D}
-    ismissing(cache!Self) && (cache!Self = initializeParamDataCache())
-    computeIntegral(OneBodyIntegral{D}(), operator.core, (orb1, orb2); 
-                    cache!Self, lazyCompute)
+    computeLayoutIntegral(config.core, (orb1, orb2); 
+                          cache!Self, estimatorConfig, lazyCompute)
 end
 
-eKinetics(basisSet::OrbBasisVec{T, D}, 
-          operator::KineticEnergySampler{T, D}=genKineticEnergySampler(T, Count(D)); 
-          cache!Self::ParamDataCache=initializeParamDataCache()) where {T<:Real, D} = 
-computeIntTensor(OneBodyIntegral{D}(), operator.core, basisSet; cache!Self)
+function eKinetics(basisSet::OrbBasisVector{T, D}, 
+                   config::KineticEnergySampler{T, D}=genKineticEnergySampler(T, Count(D)); 
+                   cache!Self::ParamDataCache=initializeParamDataCache(), 
+                   estimatorConfig::OptEstimatorConfig{T}=missing, 
+                   lazyCompute::Boolean=True()) where {T<:Real, D}
+    computeVectorIntegral(OneBodyIntegral{D, T}(), config.core, basisSet; 
+                          cache!Self, estimatorConfig, lazyCompute)
+end

--- a/src/Precompilation.jl
+++ b/src/Precompilation.jl
@@ -16,7 +16,6 @@ function precompileField(field::FieldAmplitude{C, D}, ::Val{B}=Val(false)) where
 
         primBasisMD(centerInput)
         primBasisMN(centerInput)
-        genOrbitalData(primBasisMD)
 
         primBasesD = [primBasisMD, primBasisPD]
         primBasesN = [primBasisMN, primBasisPN]
@@ -29,7 +28,6 @@ function precompileField(field::FieldAmplitude{C, D}, ::Val{B}=Val(false)) where
         compBasisDD(centerInput)
         compBasisND(centerInput)
         compBasisNN(centerInput)
-        genOrbitalData(compBasisDD, True())
     end
 
     nothing

--- a/src/Spatial.jl
+++ b/src/Spatial.jl
@@ -448,8 +448,9 @@ const StashedShiftedField{T<:Real, D, C<:RealOrComplex{T}, F<:ShiftedFieldFuncCo
                           V<:OptSpanValueSet} = 
       StashedField{T, D, C, F, V}
 
-const FloatingPolyGaussField{T<:Real, D, F<:PolyGaussFieldCore{T, D}, 
-                             R<:FieldCenterShifter{T, D}, V<:OptSpanValueSet} = 
+const FloatingPolyGaussField{T<:Real, D, 
+                             F<:ShiftedFieldFuncCore{T, D, <:PolyGaussFieldCore{T, D}}, 
+                             V<:OptSpanValueSet} = 
       StashedShiftedField{T, D, T, F, V}
 
 

--- a/src/Spatial.jl
+++ b/src/Spatial.jl
@@ -60,7 +60,7 @@ const NullaryFieldFunc{T<:Real, D, C<:RealOrComplex{T}, F<:AbstractParamFunc} =
       FieldParamFunc{T, D, C, F, VoidSetFilter}
 
 
-struct StashedField{T, D, C<:RealOrComplex{T}, F<:AbstractParamFunc, 
+struct StashedField{T<:Real, D, C<:RealOrComplex{T}, F<:AbstractParamFunc, 
                     V<:OptSpanValueSet} <: FieldAmplitude{C, D}
     core::TypedCarteFunc{C, D, F}
     data::V
@@ -498,4 +498,15 @@ function strictTypeJoin(::Type{ShiftedField{TL, D, CL, FL, RL}},
     p = (;T=strictTypeJoin(TL, TR), D, C=strictTypeJoin(CL, CR), F=strictTypeJoin(FL, FR), 
           R=strictTypeJoin(RL, RR))
     typeintersect(genParametricType(ShiftedField, p), ShiftedField)
+end
+
+function strictTypeJoin(::Type{StashedField{TL, D, CL, FL, VL}}, 
+                        ::Type{StashedField{TR, D, CR, FR, VR}}) where 
+                       {D, TL<:Real, CL<:RealOrComplex{TL}, FL<:AbstractParamFunc, 
+                           VL<:OptSpanValueSet, 
+                           TR<:Real, CR<:RealOrComplex{TL}, FR<:AbstractParamFunc, 
+                           VR<:OptSpanValueSet}
+    p = (;T=strictTypeJoin(TL, TR), D, C=strictTypeJoin(CL, CR), F=strictTypeJoin(FL, FR), 
+          V=strictTypeJoin(VL, VR))
+    typeintersect(genParametricType(StashedField, p), StashedField)
 end

--- a/test/unit-tests/Integration/Framework-test.jl
+++ b/test/unit-tests/Integration/Framework-test.jl
@@ -1,14 +1,67 @@
 using Test
-using Quiqbox: BasisIndexList, OneToIndex
+using Quiqbox
+using Quiqbox: MultiOrbitalData, PrimOrbPointer, CompOrbPointer, OneToIndex, MemoryPair, 
+               markObj, buildOrbCoreWeight!, absSqrtInv
 
 @testset "Types.jl" begin
 
-bList1 = BasisIndexList(3)
-bList2 = BasisIndexList((3,))
-@test length(bList1.index) == length(bList2.index) == 3
-@test bList1.endpoint == bList2.endpoint == [OneToIndex(), OneToIndex(4)]
-bList3 = BasisIndexList([1, 2])
-@test length(bList3.index) == 3
-@test bList3.endpoint == [OneToIndex(), OneToIndex(2), OneToIndex(4)]
+pgto1 = genGaussTypeOrb((0.0, 0.0, 1.0), 2.0, (1, 1, 0), renormalize=true )
+pgto2 = genGaussTypeOrb((0.0, 1.0, 0.0), 3.0, (0, 0, 0), renormalize=true )
+pgto3 = genGaussTypeOrb((1.0, 0.0, 1.0), 4.0, (1, 1, 2), renormalize=true )
+pgto4 = genGaussTypeOrb((1.0, 0.0, 1.0), 4.0, (1, 1, 2), renormalize=false)
+
+ cons = [2.0, -1.0, 3.0]
+cgto1 = CompositeOrb([pgto1, pgto2, pgto3], cons, renormalize=false)
+cgto2 = CompositeOrb([pgto1, pgto2, pgto3], cons, renormalize=true )
+cgto3 = CompositeOrb([pgto2, pgto1, pgto4], cons, renormalize=false)
+cgto4 = CompositeOrb([pgto2, pgto1, pgto4], cons, renormalize=true )
+cgto5 = CompositeOrb([pgto4], [1.0], renormalize=true)
+
+bs = Quiqbox.genMemory([pgto1, pgto4, cgto1, cgto2, cgto3, cgto4, cgto5])
+data = MultiOrbitalData(bs)
+
+@test length(data.config) == 3
+ptr1 = Quiqbox.PrimOrbPointer{3, Float64}(OneToIndex(1), true )
+ptr2 = Quiqbox.PrimOrbPointer{3, Float64}(OneToIndex(3), true )
+ptr3 = Quiqbox.PrimOrbPointer{3, Float64}(OneToIndex(2), true )
+ptr4 = Quiqbox.PrimOrbPointer{3, Float64}(OneToIndex(2), false)
+ptr5 = Quiqbox.CompOrbPointer{3, Float64}(MemoryPair([ptr1, ptr2, ptr3], cons), false)
+ptr6 = Quiqbox.CompOrbPointer{3, Float64}(ptr5.inner, true)
+ptr7 = Quiqbox.CompOrbPointer{3, Float64}(MemoryPair([ptr2, ptr1, ptr4], cons), false)
+ptr8 = Quiqbox.CompOrbPointer{3, Float64}(ptr7.inner, true)
+ptr9 = Quiqbox.CompOrbPointer{3, Float64}(MemoryPair([ptr4], [1.0]), true)
+@test data.format[1] == ptr1
+@test data.format[2] == ptr4
+@test markObj(data.format[3]) == markObj(ptr5)
+@test markObj(data.format[4]) == markObj(ptr6)
+@test markObj(data.format[5]) == markObj(ptr7)
+@test markObj(data.format[6]) == markObj(ptr8)
+@test markObj(data.format[7]) == markObj(ptr9)
+
+for bl in (Quiqbox.True(), Quiqbox.False())
+
+    normInfo = Quiqbox.initializeOrbIntegral(Quiqbox.OneBodyIntegral{3, Float64}(), 
+                                             Quiqbox.genOverlapSampler(), data, bl)
+    @test absSqrtInv(overlap(pgto4, pgto4)) == buildOrbCoreWeight!(normInfo, ptr9)[] == 
+                                               buildOrbCoreWeight!(normInfo, ptr3)[]
+
+    ws1 = buildOrbCoreWeight!.(Ref(normInfo), [ptr1, ptr2, ptr3]) .* cons
+    @test cons' * overlaps(cgto1.basis) * cons ≈ overlap(cgto1, cgto1) == 
+           ws1' * overlaps(PrimitiveOrb.(cgto1.basis, renormalize=false)) * ws1
+    @test ws1 == buildOrbCoreWeight!(normInfo, ptr5)
+    @test ws1[end] == (absSqrtInv∘overlap)(pgto4, pgto4) * cons[end]
+
+    ws2 = buildOrbCoreWeight!(normInfo, ptr6)
+    @test overlap(cgto2, cgto2) ≈ 1 ≈ 
+          ws2' * overlaps(PrimitiveOrb.(cgto2.basis, renormalize=false)) * ws2
+
+    ws3 = buildOrbCoreWeight!(normInfo, ptr7)
+    @test cons' * overlaps(cgto3.basis) * cons ≈ overlap(cgto3, cgto3) == 
+           ws3' * overlaps(PrimitiveOrb.(cgto3.basis, renormalize=false)) * ws3
+
+    ws4 = buildOrbCoreWeight!(normInfo, ptr8)
+    @test overlap(cgto4, cgto4) ≈ 1 ≈ 
+          ws4' * overlaps(PrimitiveOrb.(cgto4.basis, renormalize=false)) * ws4
+end
 
 end

--- a/test/unit-tests/Integration/Interface-test.jl
+++ b/test/unit-tests/Integration/Interface-test.jl
@@ -16,18 +16,9 @@ cons2 = [1.0,  0.8]
 cgf1 = genGaussTypeOrb(cen1, xpns1, cons1, (1, 0, 0))
 cgf2 = genGaussTypeOrb(cen2, xpns2, cons2, (1, 0, 0))
 
-bs1 = cgf1.basis
-cgf1compData = Quiqbox.genOrbitalData(cgf1.basis)
-normCache = Quiqbox.initializeOverlapCache(cgf1compData)
-
-s1 = Quiqbox.overlaps(bs1)
+s1 = Quiqbox.overlaps(cgf1.basis)
 ovlp1 = dot(cons1, s1, cons1)
 @test ovlp1 ≈ 0.2844258928014478
-
-oCache = Quiqbox.OrbCoreMarkerDict{Float64, 3}()
-idxers = Quiqbox.prepareIntegralConfig!(normCache, normCache, oCache, cgf1compData)
-s1_2 = Quiqbox.buildIntegralTensor(normCache, idxers)
-@test s1_2 == s1
 
 cgf1n = genGaussTypeOrb(cen1, xpns1, cons1, (1, 0, 0), 
                         innerRenormalize=true, outerRenormalize=true)
@@ -36,13 +27,13 @@ cgf2n = genGaussTypeOrb(cen2, xpns2, cons2, (1, 0, 0),
 ovlp1_2 = Quiqbox.overlap(cgf1, cgf1)
 @test ovlp1_2 ≈ 0.2844258928014479
 
-ovlp1_3 = Quiqbox.overlap(cgf1, cgf1, lazyCompute=true)
+ovlp1_3 = Quiqbox.overlap(cgf1, cgf1, lazyCompute=Quiqbox.False())
 @test ovlp1_2 ≈ ovlp1_3
 
 s2 = [0.2844258928014478 0.2894349248354434; 0.2894349248354434 2.0052505884348175]
 @test Quiqbox.overlap(cgf1, cgf2) ≈ s2[2]
 @test Quiqbox.overlaps([cgf1, cgf2]) ≈ s2
-@test Quiqbox.overlap(cgf1, cgf2) ≈ Quiqbox.overlap(cgf1, cgf2, lazyCompute=true)
+@test Quiqbox.overlap(cgf1, cgf2) ≈ Quiqbox.overlap(cgf1, cgf2, lazyCompute=Quiqbox.False())
 
 mmCen = (1.0, 2.0, 3.0)
 mmDeg = (1, 2, 3)
@@ -54,6 +45,6 @@ cgf3 = genGaussTypeOrb(cen1, xpns1, cons1, (3, 0, 0))
 @test Quiqbox.multipoleMoment(cen1, (2, 0, 0), cgf2, cgf1) == Quiqbox.overlap(cgf2, cgf3)
 @test Quiqbox.multipoleMoment(cen1, (2, 0, 0), cgf1, cgf2) ≈ Quiqbox.overlap(cgf2, cgf3)
 @test multipoleMoment((1.0, 0.0, 0.0), (2, 2, 2), cgf1, cgf1) == 
-multipoleMoment((1.0, 0.0, 0.0), (2, 2, 2), cgf1, cgf1, lazyCompute=true)
+multipoleMoment((1.0, 0.0, 0.0), (2, 2, 2), cgf1, cgf1, lazyCompute=Quiqbox.False())
 
 end

--- a/test/unit-tests/Integration/Interface-test.jl
+++ b/test/unit-tests/Integration/Interface-test.jl
@@ -33,7 +33,7 @@ ovlp1_3 = Quiqbox.overlap(cgf1, cgf1, lazyCompute=Quiqbox.False())
 s2 = [0.2844258928014478 0.2894349248354434; 0.2894349248354434 2.0052505884348175]
 @test Quiqbox.overlap(cgf1, cgf2) ≈ s2[2]
 @test Quiqbox.overlaps([cgf1, cgf2]) ≈ s2
-@test Quiqbox.overlap(cgf1, cgf2) ≈ Quiqbox.overlap(cgf1, cgf2, lazyCompute=Quiqbox.False())
+@test Quiqbox.overlap(cgf1, cgf2) ≈ Quiqbox.overlap(cgf1, cgf2, lazyCompute=false)
 
 mmCen = (1.0, 2.0, 3.0)
 mmDeg = (1, 2, 3)
@@ -45,6 +45,6 @@ cgf3 = genGaussTypeOrb(cen1, xpns1, cons1, (3, 0, 0))
 @test Quiqbox.multipoleMoment(cen1, (2, 0, 0), cgf2, cgf1) == Quiqbox.overlap(cgf2, cgf3)
 @test Quiqbox.multipoleMoment(cen1, (2, 0, 0), cgf1, cgf2) ≈ Quiqbox.overlap(cgf2, cgf3)
 @test multipoleMoment((1.0, 0.0, 0.0), (2, 2, 2), cgf1, cgf1) == 
-multipoleMoment((1.0, 0.0, 0.0), (2, 2, 2), cgf1, cgf1, lazyCompute=Quiqbox.False())
+      multipoleMoment((1.0, 0.0, 0.0), (2, 2, 2), cgf1, cgf1, lazyCompute=false)
 
 end

--- a/test/unit-tests/Integration/Kinetic-test.jl
+++ b/test/unit-tests/Integration/Kinetic-test.jl
@@ -41,7 +41,6 @@ pgf1_masked = PrimitiveOrb((0., 0., 0.), Quiqbox.EncodedField( pgf1, Float64, Co
 @test eKinetic(pgf1, pgf1, lazyCompute=Quiqbox.False()) ≈ 0.43502562475512524
 
 cgf1 = genGaussTypeOrb((1.1, 0.5, 1.1), [1.2, 0.6], [1.5, -0.3], (1, 2, 2))
-@test eKinetic(cgf1, cgf1) ≈ eKinetic(cgf1, cgf1, lazyCompute=Quiqbox.False()) ≈ 
-      0.06737210531634309
+@test eKinetic(cgf1, cgf1) ≈ eKinetic(cgf1, cgf1, lazyCompute=false) ≈ 0.06737210531634309
 
 end

--- a/test/unit-tests/Integration/Kinetic-test.jl
+++ b/test/unit-tests/Integration/Kinetic-test.jl
@@ -34,12 +34,14 @@ ke1mat = eKinetics([sto1])
 @test unique(eKinetics([sto1, sto1]))[] == ke1
 
 pgf1 = genGaussTypeOrb((0.1, 0.2, 0.3), 2.0, (1, 0, 0))
-@test eKinetic(pgf1, pgf1) ≈ eKinetic(pgf1, pgf1, lazyCompute=true) ≈ 0.4350256247524772
+@test eKinetic(pgf1, pgf1) ≈ eKinetic(pgf1, pgf1, lazyCompute=Quiqbox.False()) ≈ 
+      0.4350256247524772
 pgf1_masked = PrimitiveOrb((0., 0., 0.), Quiqbox.EncodedField( pgf1, Float64, Count(3) ))
 @test eKinetic(pgf1_masked, pgf1) ≈ eKinetic(pgf1, pgf1) ≈ 0.43502562475512524
-@test eKinetic(pgf1, pgf1, lazyCompute=true) ≈ 0.43502562475512524
+@test eKinetic(pgf1, pgf1, lazyCompute=Quiqbox.False()) ≈ 0.43502562475512524
 
 cgf1 = genGaussTypeOrb((1.1, 0.5, 1.1), [1.2, 0.6], [1.5, -0.3], (1, 2, 2))
-@test eKinetic(cgf1, cgf1) ≈ eKinetic(cgf1, cgf1, lazyCompute=true) ≈ 0.06737210531634309
+@test eKinetic(cgf1, cgf1) ≈ eKinetic(cgf1, cgf1, lazyCompute=Quiqbox.False()) ≈ 
+      0.06737210531634309
 
 end

--- a/test/unit-tests/Integration/Overlap-test.jl
+++ b/test/unit-tests/Integration/Overlap-test.jl
@@ -4,6 +4,7 @@ using Quiqbox: overlap, overlaps
 using LinearAlgebra: norm
 
 @testset "Overlap-Based Features" begin
+
 xpnL, xpnR = (1.0, 1.5)
 cenL, cenR = (2.0, 3.1)
 angL, angR = (2,   4  )
@@ -56,34 +57,6 @@ sto1 = Quiqbox.PolyRadialFunc(stf1, (1, 1, 0))
 @test Quiqbox.unpackFunc(sto1)[begin] isa Quiqbox.PolyRadialFieldFunc
 stoBasis1 = Quiqbox.PrimitiveOrb((1.0, 2.0, 3.0), sto1; renormalize=false)
 @test overlap(stoBasis1, stoBasis1) ≈ 4.7123889802878764
-# @profview overlap(stoBasis1, stoBasis1)
-
-# using BenchmarkTools
-# @benchmark overlap($stoBasis1, $stoBasis1)
-
-# julia> @benchmark overlap($stoBasis1, $stoBasis1)
-# BenchmarkTools.Trial: 4 samples with 1 evaluation per sample.
-#  Range (min … max):  1.299 s …   1.336 s  ┊ GC (min … max): 0.27% … 2.29%
-#  Time  (median):     1.313 s              ┊ GC (median):    0.53%
-#  Time  (mean ± σ):   1.315 s ± 15.546 ms  ┊ GC (mean ± σ):  0.91% ± 0.94%
-
-#   █                █         █                            █
-#   █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
-#   1.3 s          Histogram: frequency by time        1.34 s <
-
-#  Memory estimate: 107.77 MiB, allocs estimate: 791.
-
-# julia>   @benchmark overlap($stoBasis1, $stoBasis1) # 20250609
-# BenchmarkTools.Trial: 4 samples with 1 evaluation per sample.
-#  Range (min … max):  1.275 s …   1.317 s  ┊ GC (min … max): 0.25% … 2.18%
-#  Time  (median):     1.285 s              ┊ GC (median):    0.50%
-#  Time  (mean ± σ):   1.291 s ± 19.100 ms  ┊ GC (mean ± σ):  0.86% ± 0.89%
-
-#   █   █                 █                                 █  
-#   █▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
-#   1.28 s         Histogram: frequency by time        1.32 s <
-
-#  Memory estimate: 107.76 MiB, allocs estimate: 417.
 
 sto2 = Quiqbox.PolyRadialFunc(stf1, (2,))
 stoBasis2 = Quiqbox.PrimitiveOrb((1.0,), sto2; renormalize=false)
@@ -94,9 +67,9 @@ stoBasis1n_c, stoBasis1n_s = Quiqbox.unpackFunc(stoBasis1n);
 overlap(stoBasis1n, stoBasis1n) ≈ 1
 s2 = sqrt(overlap(stoBasis1, stoBasis1)) # 2.170803763600724
 @test overlap(stoBasis1n, stoBasis1) ≈ overlap(stoBasis1, stoBasis1n) ≈ s2
-@test overlap(stoBasis1n, stoBasis1, lazyCompute=true) ≈ 
-      overlap(stoBasis1, stoBasis1n, lazyCompute=true) ≈ 
-      sqrt(overlap(stoBasis1, stoBasis1, lazyCompute=true)) ≈ s2
+@test overlap(stoBasis1n, stoBasis1, lazyCompute=Quiqbox.False()) ≈ 
+      overlap(stoBasis1, stoBasis1n, lazyCompute=Quiqbox.False()) ≈ 
+      sqrt(overlap( stoBasis1, stoBasis1, lazyCompute=Quiqbox.False() )) ≈ s2
 
 cen2 = (1.0, 1.5, 1.1)
 xpns2 = [1.5, 0.6]
@@ -119,7 +92,6 @@ s4 = overlap(cgf2n1, cgf2n3)
 @test overlap(cgf2n2, cgf2n2) ≈ 1
 @test overlap(cgf2n3, cgf2n3) ≈ 1
 @test !(overlap(cgf2n2, cgf2n3) ≈ 1)
-Quiqbox.decomposeOrbData(cgf2n2|>genOrbitalData)
 
 consH = [0.1543289673, 0.5353281423, 0.4446345422]
 bfH = genGaussTypeOrb((0., 0., 0.), [3.425250914, 0.6239137298, 0.1688554040], 
@@ -153,8 +125,8 @@ bsLiH = [bfH, bfLi1, bfLi2, bfLi3, bfLi4, bfLi5]
 @test all(Quiqbox.isRenormalized(o) for o in Quiqbox.splitOrb(bsLiH[1]))
 
 @test overlap(bsLiH[1], bsLiH[1]) ≈ 1
-@test overlap(bsLiH[1], bsLiH[1], lazyCompute=true) ≈ 1
-@test overlap(bsLiH[1], deepcopy(bsLiH[1]), lazyCompute=true) ≈ 1
+@test overlap(bsLiH[1], bsLiH[1], lazyCompute=Quiqbox.False()) ≈ 1
+@test overlap(bsLiH[1], deepcopy(bsLiH[1]), lazyCompute=Quiqbox.False()) ≈ 1
 
 gfHs = Quiqbox.splitOrb(bfH_t)
 s_gfHs = [0.3105569331128749 0.6834026444177144 0.8172189509285114; 

--- a/test/unit-tests/Integration/Overlap-test.jl
+++ b/test/unit-tests/Integration/Overlap-test.jl
@@ -69,11 +69,11 @@ s2 = sqrt(overlap(stoBasis1, stoBasis1)) # 2.170803763600724
 @test overlap(stoBasis1n, stoBasis1) ≈ overlap(stoBasis1, stoBasis1n) ≈ s2
 @test overlap(stoBasis1n, stoBasis1, lazyCompute=Quiqbox.False()) ≈ 
       overlap(stoBasis1, stoBasis1n, lazyCompute=Quiqbox.False()) ≈ 
-      sqrt(overlap( stoBasis1, stoBasis1, lazyCompute=Quiqbox.False() )) ≈ s2
+      sqrt(overlap(stoBasis1, stoBasis1, lazyCompute=false)) ≈ s2
 
 cen2 = (1.0, 1.5, 1.1)
 xpns2 = [1.5, 0.6]
-cons2 = [1.0,  0.8]
+cons2 = [1.0, 0.8]
 cgf2 = genGaussTypeOrb(cen2, xpns2, cons2, (1, 0, 0))
 cgf2n1 = genGaussTypeOrb(cen2, xpns2, cons2, (1, 0, 0), innerRenormalize=true, 
                          outerRenormalize=false)
@@ -125,8 +125,8 @@ bsLiH = [bfH, bfLi1, bfLi2, bfLi3, bfLi4, bfLi5]
 @test all(Quiqbox.isRenormalized(o) for o in Quiqbox.splitOrb(bsLiH[1]))
 
 @test overlap(bsLiH[1], bsLiH[1]) ≈ 1
-@test overlap(bsLiH[1], bsLiH[1], lazyCompute=Quiqbox.False()) ≈ 1
-@test overlap(bsLiH[1], deepcopy(bsLiH[1]), lazyCompute=Quiqbox.False()) ≈ 1
+@test overlap(bsLiH[1], bsLiH[1], lazyCompute=false) ≈ 1
+@test overlap(bsLiH[1], deepcopy(bsLiH[1]), lazyCompute=false) ≈ 1
 
 gfHs = Quiqbox.splitOrb(bfH_t)
 s_gfHs = [0.3105569331128749 0.6834026444177144 0.8172189509285114; 

--- a/test/unit-tests/Spatial-test.jl
+++ b/test/unit-tests/Spatial-test.jl
@@ -45,4 +45,8 @@ for a_x in 0:3
     @test pgf(( 1., 0., 0.)) == gf4_val1
 end
 
+pgto1 = genGaussTypeOrb((0., 1., 0.), 2.5, (1, 1, 0))
+pgto1Core, paramSet = Quiqbox.unpackFunc(pgto1.field)
+Quiqbox.StashedField(pgto1Core, paramSet) isa Quiqbox.FloatingPolyGaussField
+
 end

--- a/test/unit-tests/SpatialBasis-test.jl
+++ b/test/unit-tests/SpatialBasis-test.jl
@@ -14,10 +14,6 @@ gf1_3dCore, par_gf1 = Quiqbox.unpackFunc(gf1_3d)
 cen1 = (0.0, 0.0, 0.0)
 ijk1 = (0, 1, 1)
 pgto1 = genGaussTypeOrb(cen1, 1.2, ijk1)
-pgto1Data = genOrbitalData(pgto1)
-@test pgto1Data isa Quiqbox.PrimOrbData
-@test pgto1Data isa Quiqbox.PGTOrbData
-
 pgto1core, par_pgto1 = Quiqbox.unpackFunc(pgto1);
 @test pgto1 isa Quiqbox.PrimGTO
 @test pgto1core isa Quiqbox.ParamBindFunc
@@ -39,10 +35,6 @@ cgto1core, par_cgto1 = Quiqbox.unpackFunc(cgto1);
 @test cgto1 isa Quiqbox.CompGTO
 @test cgto1core isa Quiqbox.ParamBindFunc
 
-coord2 = (0.2, 1.1, 2.1)
-cgto1Data = genOrbitalData(cgto1)
-@test cgto1Data isa Quiqbox.CompOrbData
-
 xpns1 = [1.2, 2.2, 3.1]
 pgf = genGaussTypeOrb(cen1, xpns1[1], ijk1)
 @test !compareParamBox(pgf.field.center[1], pgf.field.center[2])
@@ -51,6 +43,7 @@ cgto2 = genGaussTypeOrb(cen1, xpns1, cons1, ijk1)
 @test cgto2 isa Quiqbox.CompGTO
 cgto2core, par_cgto2 = Quiqbox.unpackFunc(cgto2);
 
+coord2 = (0.2, 1.1, 2.1)
 compute_cgto = function (dr, xpn, con, ijk)
     prod(dr .^ ijk) * exp(-xpn*norm(dr)^2) * con
 end

--- a/test/unit-tests/Types-test.jl
+++ b/test/unit-tests/Types-test.jl
@@ -68,8 +68,6 @@ end
 
 @test Quiqbox.FixedSpanParamSet <: Quiqbox.TypedSpanParamSet
 
-@test Quiqbox.PGTOrbData <: Quiqbox.PrimOrbData
-
 @test Quiqbox.ParamMapper <: Quiqbox.ChainMapper
 
 @test Quiqbox.NamedParamMapper <: Quiqbox.ParamMapper


### PR DESCRIPTION
- Simplified `ParamPipeline` to `ParamPipeFunc` to remove support for arbitrary numbers of chained ParamFunc.
- Commits revolving around bb9fd4f9b690982ab07cc5e0e155dce65150c263: Refactored the integration framework.
  1. Compressed and moved orbital decoding-encoding to the beginning by replacing `OrbitalData` with `MultiOrbitalData`. 
  2. Improved the simplicity and extensibility of the symmetry-aware cache-based integration system by specifying index symmetry and op-orb symmetry.
