### PR TITLE
0.6-Optimization Dev

### DIFF
--- a/src/Caches.jl
+++ b/src/Caches.jl
@@ -261,8 +261,8 @@ function recordInputKey!(b::CacheBlock, hasKey::Bool)
 end
 
 
-function checkEval(hashFunc::F, callObj::Boolean, obj, d::PseudoLRU{K}, key::K, 
-                   trackStatistic::MissingOr{Bool}=missing) where {K, F<:CommonCallable}
+function checkEval(hashFunc::F, callObj::Boolean, obj::T, d::PseudoLRU{K}, key::K, 
+                   trackStatistic::MissingOr{Bool}=missing) where {F<:CommonCallable, T, K}
     d.shape.first > 0 || (return evalObj(callObj, obj))
 
     block, startIdx = locateHashBlock(d, key, hashFunc)
@@ -298,9 +298,9 @@ function get(f::CommonCallable, d::PseudoLRU{K}, key::K, hashFunc::F=baseHash) w
 end
 
 
-function directSet!(callObj::Boolean, obj, block::CacheBlock{K, V}, 
+function directSet!(callObj::Boolean, obj::T, block::CacheBlock{K, V}, 
                     info::Pair{K, OneToIndex}, creditQuota::Pair{OctalNumber, OctalNumber}
-                    ) where {K, V}
+                    ) where {T, K, V}
     key, idx = info
     objVal = evalObj(callObj, obj)
     cPair = CreditPair{K, V}(key=>objVal, creditQuota)
@@ -308,8 +308,9 @@ function directSet!(callObj::Boolean, obj, block::CacheBlock{K, V},
     objVal
 end
 
-function checkSet!(hashFunc::F, callObj::Boolean, obj, d::PseudoLRU{K, V}, key::K, 
-                   trackStatistic::MissingOr{Bool}=missing) where {K, V, F<:CommonCallable}
+function checkSet!(hashFunc::F, callObj::Boolean, obj::T, d::PseudoLRU{K, V}, key::K, 
+                   trackStatistic::MissingOr{Bool}=missing) where 
+                  {F<:CommonCallable, T, K, V}
     d.shape.first > 0 || (return evalObj(callObj, obj))
 
     block, startIdx = locateHashBlock(d, key, hashFunc)

--- a/src/Caches.jl
+++ b/src/Caches.jl
@@ -1,5 +1,3 @@
-const baseHash = Base.hash
-
 #>/ Custom pseudo LRU (least-recent used) cache \<#
 function checkCreditQuota(initial::Union{Integer, OctalNumber}, 
                           ceiling::Union{Integer, OctalNumber})

--- a/src/Query.jl
+++ b/src/Query.jl
@@ -1,5 +1,5 @@
 using LRUCache
-using Base: issingletontype
+using Base: issingletontype, hash as baseHash
 
 struct OneToIndex <: CustomAccessor
     idx::Int
@@ -186,11 +186,14 @@ collect(::EmptyDict{K, V}) where {K, V} = Memory{Pair{K, V}}(undef, 0)
 
 haskey(::EmptyDict{K}, ::K) where {K} = false
 
-get(::EmptyDict{K}, ::K, default::Any) where {K} = itself(default)
+get(::EmptyDict{K}, ::K, default::Any, _::CommonCallable=baseHash) where {K} = 
+itself(default)
 
-get!(::EmptyDict{K, V}, ::K, default::V) where {K, V} = itself(default)
+get!(::EmptyDict{K, V}, ::K, default::V, _::CommonCallable=baseHash) where {K, V} = 
+itself(default)
 
-get!(f::CommonCallable, ::EmptyDict{K}, ::K) where {K} = f()
+get!(f::CommonCallable, ::EmptyDict{K}, ::K, _::CommonCallable=baseHash) where {K} = 
+f()
 
 setindex!(d::EmptyDict{K, V}, ::V, ::K) where {K, V} = itself(d)
 


### PR DESCRIPTION
- Extended `get` and `get!` for `EmptyDict` to allow custom hash functions.
- Enforced specialization of `obj` in `checkEval` and `checkSet!` to avoid huge allocation buildup.